### PR TITLE
fix: refactor settings to enable accepting, move validations on_update

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,9 +138,12 @@ export WISE_ACCOUNT_ID='your_sandbox_business_account_profile_id'
 
 3. Run the script to install the demo data. If you have API keys set as environment variables, the script will look for them to automatically create an Electronic Payments Settings document (necessary to test payment functionality). It will first check for any present, if it finds multiple keys, then it will create using alphabetical ordering and the following logic:
 
-- If Authorize.net keys are present, then it uses that provider for both accepting and sending payments. If there are no Authorize.net keys, it then checks for Stripe keys
-- If Stripe keys are present, it uses Stripe as the accepting provider. If Mercury keys are also present, it enables sending payments and uses Mercury as the sending provider. If Mercury is not present but Wise is, then it'll enable sending payments with Wise as the sending provider (if neither are found, the script won't enable sending payments)
-- If Stripe keys are not present the script won't create an Electronic Payments Settings doc (this may be done manually in the test site later). This is because Mercury and Wise are not set up to accept payments
+- If Authorize.net keys are present, then it uses that provider for both accepting and sending payments
+- If there are no Authorize.net keys, but Stripe keys are present, it uses Stripe as the accepting provider.
+- If neither are present, the script won't enable accepting payments
+- If there are no Authorize.net keys, but Mercury keys are present, it uses Mercury as the sending provider
+- If there are no Authorize.net or Mercury keys, but Wise keys are present, it uses Wise as the sending provider
+- If no sending providers are found, the script won't enable sending payments
 
 If you have API keys for more than one provider, you can pass `a_provider` and `s_provider` arguments when executing the test script to specify which one to use for accepting and sending payments, respectively. The argument is the lowercase letter of the first initial of the provider's name. If the specified provider's keys aren't present, the script won't create the Electronic Payments Settings document.
 ```shell

--- a/electronic_payments/electronic_payments/doctype/electronic_payment_settings/authorize.py
+++ b/electronic_payments/electronic_payments/doctype/electronic_payment_settings/authorize.py
@@ -38,7 +38,7 @@ class AuthorizeNet:
 	def merchant_auth(self, company):
 		settings = frappe.get_doc("Electronic Payment Settings", {"company": company})
 		if not settings:
-			frappe.msgprint(_(f"No Electronic Payment Settings found for {company}-Authorize.net"))
+			frappe.msgprint(_(f"No Electronic Payment Settings found for {company}"))
 		else:
 			api_key_field = "api_key" if settings.provider == "Authorize.net" else "sending_api_key"
 			txn_key_field = (

--- a/electronic_payments/electronic_payments/doctype/electronic_payment_settings/electronic_payment_settings.json
+++ b/electronic_payments/electronic_payments/doctype/electronic_payment_settings/electronic_payment_settings.json
@@ -1,13 +1,15 @@
 {
 	"actions": [],
-	"autoname": "format:{company}-{provider}",
+	"autoname": "format:{company}",
 	"creation": "2022-12-20 13:22:13.760162",
 	"doctype": "DocType",
 	"editable_grid": 1,
 	"engine": "InnoDB",
 	"field_order": [
+		"accepting_payments_tab",
 		"company",
 		"create_ppm",
+		"enable_accepting",
 		"accepting_config_section",
 		"provider",
 		"ref_id",
@@ -58,12 +60,14 @@
 		{
 			"fieldname": "api_key",
 			"fieldtype": "Password",
-			"label": "API Key"
+			"label": "API Key",
+			"mandatory_depends_on": "enable_accepting"
 		},
 		{
 			"fieldname": "transaction_key",
 			"fieldtype": "Password",
-			"label": "Transaction Key"
+			"label": "Transaction Key",
+			"mandatory_depends_on": "eval:doc.enable_accepting && doc.provider === \"Authorize.net\""
 		},
 		{
 			"fieldname": "ref_id",
@@ -71,6 +75,7 @@
 			"label": "Merchant ID"
 		},
 		{
+			"depends_on": "enable_accepting",
 			"fieldname": "section_break_5",
 			"fieldtype": "Section Break",
 			"label": "Accounts: Accepting Payments"
@@ -91,22 +96,22 @@
 			"fieldname": "provider",
 			"fieldtype": "Select",
 			"label": "Provider",
-			"options": "\nAuthorize.net\nStripe",
-			"reqd": 1
+			"mandatory_depends_on": "enable_accepting",
+			"options": "\nAuthorize.net\nStripe"
 		},
 		{
 			"fieldname": "endpoint",
 			"fieldtype": "Data",
 			"label": "Endpoint",
-			"mandatory_depends_on": "eval:doc.provider === \"Authorize.net\""
+			"mandatory_depends_on": "eval:doc.enable_accepting && doc.provider === \"Authorize.net\""
 		},
 		{
 			"fieldname": "deposit_account",
 			"fieldtype": "Link",
 			"in_list_view": 1,
 			"label": "Deposit Account",
-			"options": "Account",
-			"reqd": 1
+			"mandatory_depends_on": "enable_accepting",
+			"options": "Account"
 		},
 		{
 			"fieldname": "use_clearing_account",
@@ -119,14 +124,14 @@
 			"fieldtype": "Link",
 			"in_list_view": 1,
 			"label": "Provider Fee Account",
-			"options": "Account",
-			"reqd": 1
+			"mandatory_depends_on": "enable_accepting",
+			"options": "Account"
 		},
 		{
 			"fieldname": "accepting_clearing_account",
 			"fieldtype": "Link",
 			"label": "Clearing Account",
-			"mandatory_depends_on": "eval:doc.use_clearing_account === \"Use Journal Entry and Clearing Account\"",
+			"mandatory_depends_on": "eval:doc.enable_accepting && doc.use_clearing_account === \"Use Journal Entry and Clearing Account\"",
 			"options": "Account"
 		},
 		{
@@ -179,8 +184,8 @@
 			"fieldname": "accepting_payment_discount_account",
 			"fieldtype": "Link",
 			"label": "Payment Discount Account",
-			"options": "Account",
-			"reqd": 1
+			"mandatory_depends_on": "enable_accepting",
+			"options": "Account"
 		},
 		{
 			"description": "This account is credited by the discount amount.",
@@ -193,6 +198,7 @@
 			"options": "Account"
 		},
 		{
+			"depends_on": "enable_accepting",
 			"fieldname": "accepting_config_section",
 			"fieldtype": "Section Break",
 			"label": "Configuration: Accepting Payments"
@@ -215,7 +221,7 @@
 			"options": "\nAuthorize.net\nMercury\nWise"
 		},
 		{
-			"description": "Required for Mercury and Wise. For Mercury, enter the Mercury Account ID for the account making transfers. For Wise, enter the Wise Profile ID for the Company making transfers. If not known, enter API credentials and click Save. The error message will display the options and their IDs, if any.",
+			"description": "Required for Mercury and Wise. For Mercury, enter the Mercury Account ID for the account making transfers. For Wise, enter the Wise Profile ID for the Company making transfers. If not known, enter API credentials and click Save. The message will display the options and their IDs, if any - copy the applicable one's ID into this field.",
 			"fieldname": "sending_ref_id",
 			"fieldtype": "Data",
 			"label": "Sending Merchant ID"
@@ -233,12 +239,14 @@
 		{
 			"fieldname": "sending_api_key",
 			"fieldtype": "Password",
-			"label": "Sending API Key"
+			"label": "Sending API Key",
+			"mandatory_depends_on": "enable_sending"
 		},
 		{
 			"fieldname": "sending_transaction_key",
 			"fieldtype": "Password",
-			"label": "Sending Transaction Key"
+			"label": "Sending Transaction Key",
+			"mandatory_depends_on": "eval:doc.enable_sending && (doc.provider !== doc.sending_provider) && (doc.sending_provider === \"Authorize.net\")"
 		},
 		{
 			"fieldname": "sending_mode_of_payment",
@@ -260,14 +268,14 @@
 		{
 			"default": "0",
 			"depends_on": "eval:doc.sending_provider === \"Wise\"",
-			"description": "Automatically fund transfers with a Direct Debit bank account linked to the company profile configured in Wise. If unchecked, transfers must be funded manually via the Wise website.",
+			"description": "Automatically fund transfers with a Direct Debit bank account linked to the company profile configured in Wise. If unchecked, Electronic Payments will initiate the transfers, but the final funding step must be completed manually via the Wise website.",
 			"fieldname": "fund_wise_with_direct_debit",
 			"fieldtype": "Check",
 			"label": "Fund Wise Transfers with Direct Debit Account"
 		},
 		{
 			"depends_on": "fund_wise_with_direct_debit",
-			"description": "The Direct Debit bank account's Account ID in Wise. If not known, enter API credentials and click Save. The error message will display the account options and their IDs, if any.",
+			"description": "The Direct Debit bank account's Account ID in Wise. If not known, enter API credentials and click Save. The message will display the account options and their IDs, if any - copy the applicable one's ID in this field.",
 			"fieldname": "wise_linked_bank_account_id",
 			"fieldtype": "Data",
 			"label": "Wise Linked Bank Account ID"
@@ -289,10 +297,21 @@
 			"label": "Wise Bank Account Currency",
 			"mandatory_depends_on": "fund_wise_with_direct_debit",
 			"options": "USD"
+		},
+		{
+			"fieldname": "accepting_payments_tab",
+			"fieldtype": "Tab Break",
+			"label": "Accepting Payments"
+		},
+		{
+			"default": "0",
+			"fieldname": "enable_accepting",
+			"fieldtype": "Check",
+			"label": "Enable Accepting Electronic Payments"
 		}
 	],
 	"links": [],
-	"modified": "2025-05-26 09:08:22.610267",
+	"modified": "2025-06-11 17:39:56.917438",
 	"modified_by": "Administrator",
 	"module": "Electronic Payments",
 	"name": "Electronic Payment Settings",

--- a/electronic_payments/electronic_payments/doctype/electronic_payment_settings/electronic_payment_settings.py
+++ b/electronic_payments/electronic_payments/doctype/electronic_payment_settings/electronic_payment_settings.py
@@ -34,6 +34,8 @@ class ElectronicPaymentSettings(Document):
 	def validate(self):
 		self.create_electronic_payment_mop()
 		self.copy_api_config_if_same_providers()
+
+	def on_update(self):
 		self.validate_mercury_merchant_id()
 		self.validate_wise_merchant_id()
 		self.validate_wise_direct_debit_account_id()
@@ -74,19 +76,36 @@ class ElectronicPaymentSettings(Document):
 		If sending payments is enabled and accepting and sending providers match, copies API
 		configuration fields (if empty)
 		"""
-		if self.enable_sending and self.provider == self.sending_provider:
+		if self.enable_accepting and self.enable_sending and self.provider == self.sending_provider:
 			if self.ref_id and not self.sending_ref_id:
 				self.sending_ref_id = self.sending_ref_id
+			elif self.sending_ref_id and not self.ref_id:
+				self.ref_id = self.sending_ref_id
+
 			if self.endpoint and not self.sending_endpoint:
 				self.sending_endpoint = self.endpoint
+			elif self.sending_endpoint and not self.endpoint:
+				self.endpoint = self.sending_endpoint
+
 			if self.api_key and not self.sending_api_key:
 				api_key = get_decrypted_password(self.doctype, self.name, "api_key", raise_exception=False)
 				self.sending_api_key = api_key
+			elif self.sending_api_key and not self.api_key:
+				api_key = get_decrypted_password(
+					self.doctype, self.name, "sending_api_key", raise_exception=False
+				)
+				self.api_key = api_key
+
 			if self.transaction_key and not self.sending_transaction_key:
 				t_key = get_decrypted_password(
 					self.doctype, self.name, "transaction_key", raise_exception=False
 				)
 				self.sending_transaction_key = t_key
+			elif self.sending_transaction_key and not self.transaction_key:
+				t_key = get_decrypted_password(
+					self.doctype, self.name, "sending_transaction_key", raise_exception=False
+				)
+				self.transaction_key = t_key
 
 	def validate_mercury_merchant_id(self):
 		if self.enable_sending and self.sending_provider == "Mercury" and not self.sending_ref_id:
@@ -100,7 +119,7 @@ class ElectronicPaymentSettings(Document):
 					message = f"Please fill in the Merchant ID field for Mercury with the Account ID of the account making transfers. The following account options were found:<br><ul><li>{m1}</li></ul>"
 			else:
 				message = f"Please fill in the Merchant ID field for Mercury with the Account ID of the account making transfers. {accounts_resp['error']}"
-			frappe.throw(msg=message, title="Missing Required Field")
+			frappe.msgprint(msg=message, title="Missing Required Field")
 
 	def validate_wise_merchant_id(self):
 		if self.enable_sending and self.sending_provider == "Wise" and not self.sending_ref_id:
@@ -114,7 +133,7 @@ class ElectronicPaymentSettings(Document):
 					message = f"Please fill in the Merchant ID field for Wise. The following profiles were found for this account:<br><ul><li>{m1}</li></ul>"
 			else:
 				message = f"Please fill in the Merchant ID field for Wise. {profiles_resp['error']}"
-			frappe.throw(msg=message, title="Missing Required Field")
+			frappe.msgprint(msg=message, title="Missing Required Field")
 
 	def validate_wise_direct_debit_account_id(self):
 		if not self.enable_sending or not self.sending_provider == "Wise":
@@ -130,7 +149,7 @@ class ElectronicPaymentSettings(Document):
 					message = f"Please fill in the Wise Linked Bank Account ID field. The following Direct Debit Accounts were found for this profile:<br><ul><li>{m1}</li></ul>"
 			else:
 				message = f"Please fill in the Wise Linked Bank Account ID field. {accounts_resp['error']}"
-			frappe.throw(msg=message, title="Missing Required Field")
+			frappe.msgprint(msg=message, title="Missing Required Field")
 
 	def client(self, doc):
 		"""

--- a/electronic_payments/electronic_payments/doctype/electronic_payment_settings/stripe.py
+++ b/electronic_payments/electronic_payments/doctype/electronic_payment_settings/stripe.py
@@ -62,7 +62,7 @@ class Stripe:
 	def get_password(self, company):
 		settings = frappe.get_doc("Electronic Payment Settings", {"company": company})
 		if not settings:
-			frappe.msgprint(_(f"No Electronic Payment Settings found for {company}-Stripe"))
+			frappe.msgprint(_(f"No Electronic Payment Settings found for {company}"))
 		else:
 			api_key_field = "api_key" if settings.provider == "Stripe" else "sending_api_key"
 			stripe.api_key = get_decrypted_password(

--- a/electronic_payments/public/js/sales_invoice_custom.js
+++ b/electronic_payments/public/js/sales_invoice_custom.js
@@ -1,10 +1,17 @@
+// Copyright (c) 2025, AgriTheory and contributors
+// For license information, please see license.txt
+
 frappe.provide('electronic_payments')
 
 frappe.ui.form.on('Sales Invoice', {
 	refresh: frm => {
-		if (!frm.is_new() && !frm.is_dirty()) {
-			frm.add_custom_button(__('Electronic Payments'), () => {
-				electronic_payments.electronic_payments(frm)
+		if (!frm.is_new() && !frm.is_dirty() && frm.doc.company) {
+			frappe.db.get_value('Electronic Payment Settings', { company: frm.doc.company }, 'enable_accepting').then(r => {
+				if (r && r.message && r.message.enable_accepting) {
+					frm.add_custom_button(__('Electronic Payments'), () => {
+						electronic_payments.electronic_payments(frm)
+					})
+				}
 			})
 		}
 	},

--- a/electronic_payments/public/js/sales_order_custom.js
+++ b/electronic_payments/public/js/sales_order_custom.js
@@ -1,10 +1,17 @@
+// Copyright (c) 2025, AgriTheory and contributors
+// For license information, please see license.txt
+
 frappe.provide('electronic_payments')
 
 frappe.ui.form.on('Sales Order', {
 	refresh: frm => {
-		if (!frm.is_new() && !frm.is_dirty()) {
-			frm.add_custom_button(__('Electronic Payments'), () => {
-				electronic_payments.electronic_payments(frm)
+		if (!frm.is_new() && !frm.is_dirty() && frm.doc.company) {
+			frappe.db.get_value('Electronic Payment Settings', { company: frm.doc.company }, 'enable_accepting').then(r => {
+				if (r && r.message && r.message.enable_accepting) {
+					frm.add_custom_button(__('Electronic Payments'), () => {
+						electronic_payments.electronic_payments(frm)
+					})
+				}
 			})
 		}
 	},

--- a/electronic_payments/tests/setup.py
+++ b/electronic_payments/tests/setup.py
@@ -921,10 +921,8 @@ def create_electronic_payment_settings(settings):
 	stripe_present = os.environ.get("STRIPE_API_KEY")
 	wise_present = os.environ.get("WISE_API_KEY")
 
-	if not (authorize_present or stripe_present):
-		print(
-			"No API Keys found for a provider that accepts payments (Authorize.net or Stripe). Please manually create Electronic Payment Settings."
-		)
+	if not (authorize_present or stripe_present or mercury_present or wise_present):
+		print("No API Keys found for any provider. Please manually create Electronic Payment Settings.")
 		return
 
 	provider_mapping = {
@@ -974,17 +972,27 @@ def create_electronic_payment_settings(settings):
 	eps = frappe.new_doc("Electronic Payment Settings")
 	eps.company = settings.company
 	eps.create_ppm = 1
-	eps.provider = provider_mapping[pa_code]["provider"]
-	eps.ref_id = provider_mapping[pa_code].get("merchant_id")
-	eps.endpoint = provider_mapping[pa_code].get("endpoint")
-	eps.api_key = provider_mapping[pa_code]["api_key"]
-	eps.transaction_key = provider_mapping[pa_code].get("transaction_key")
-	eps.deposit_account = "1201 - Primary Checking - CFC"
-	eps.accepting_fee_account = "5223 - Electronic Payments Provider Fees - CFC"
-	eps.accepting_clearing_account = "1320 - Electronic Payments Receivable - CFC"
-	eps.accepting_payment_discount_account = frappe.get_value(
-		"Account", {"name": ["like", "%Sales - CFC%"]}, "name"
-	)
+
+	if not pa_code:
+		eps.enable_accepting = 0
+	elif pa_code and not provider_mapping[pa_code]["check"]:
+		eps.enable_accepting = 0
+		print(
+			f"No API Keys found for given accepting provider: {provider_mapping[pa_code]['provider']}. Settings will not enable accepting payments - this may be changed manually in the Electronic Payments Settings doc."
+		)
+	else:
+		eps.enable_accepting = 1
+		eps.provider = provider_mapping[pa_code]["provider"]
+		eps.ref_id = provider_mapping[pa_code].get("merchant_id")
+		eps.endpoint = provider_mapping[pa_code].get("endpoint")
+		eps.api_key = provider_mapping[pa_code]["api_key"]
+		eps.transaction_key = provider_mapping[pa_code].get("transaction_key")
+		eps.deposit_account = "1201 - Primary Checking - CFC"
+		eps.accepting_fee_account = "5223 - Electronic Payments Provider Fees - CFC"
+		eps.accepting_clearing_account = "1320 - Electronic Payments Receivable - CFC"
+		eps.accepting_payment_discount_account = frappe.get_value(
+			"Account", {"name": ["like", "%Sales - CFC%"]}, "name"
+		)
 
 	if not ps_code:
 		eps.enable_sending = 0
@@ -1010,8 +1018,8 @@ def create_electronic_payment_settings(settings):
 		eps.sending_endpoint = provider_mapping[ps_code].get("endpoint")
 		eps.sending_api_key = provider_mapping[ps_code]["api_key"]
 		eps.sending_transaction_key = provider_mapping[ps_code].get("transaction_key")
-		eps.withdrawal_account = eps.deposit_account
-		eps.sending_fee_account = eps.accepting_fee_account
+		eps.withdrawal_account = "1201 - Primary Checking - CFC"
+		eps.sending_fee_account = "5223 - Electronic Payments Provider Fees - CFC"
 		eps.sending_clearing_account = "2130 - Electronic Payments Payable - CFC"
 		eps.sending_payment_discount_account = frappe.get_value(
 			"Account", {"name": ["like", "%Miscellaneous Expenses - CFC%"]}, "name"

--- a/electronic_payments/tests/test_common_funcs.py
+++ b/electronic_payments/tests/test_common_funcs.py
@@ -32,6 +32,7 @@ def create_electronic_payment_settings(
 	)
 	eps = frappe.new_doc("Electronic Payment Settings")
 	eps.company = company
+	eps.enable_accepting = 1
 	eps.provider = provider
 	eps.api_key = "123456789"
 	eps.transaction_key = "" if provider == "Stripe" else "987654321"


### PR DESCRIPTION
closes #53 

Updates Settings to:
- Just use Company for EP Settings title
- `enable_accepting` check, related fields only required if that's set
- moved the account ID validations into `on_update` hook, and it prints a message vs throws an error. Part of this issue may have been a timing one (the validation makes an API call, which tries to find the [unsaved] Settings doc for the endpoint/API keys fields)
- I tested with a new Settings doc using sandbox endpoint and keys, and the new sequence seems to work. I used the full `https://api-sandbox.mercury.com` (production would be `https://api.mercury.com`)