### PR TITLE
feat: refactor to use base provider class

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -56,7 +56,7 @@ repos:
         args: ['-L ND']
 
   - repo: https://github.com/agritheory/test_utils
-    rev: v1.0.0
+    rev: v1.1.0
     hooks:
       - id: update_pre_commit_config
       - id: validate_copyright

--- a/electronic_payments/electronic_payments/doctype/electronic_payment_settings/authorize.py
+++ b/electronic_payments/electronic_payments/doctype/electronic_payment_settings/authorize.py
@@ -28,7 +28,6 @@ from electronic_payments.electronic_payments.doctype.electronic_payment_settings
 )
 from electronic_payments.electronic_payments.doctype.electronic_payment_settings.common import (
 	calculate_payment_method_fees,
-	exceeds_credit_limit,
 	get_discount_amount,
 	get_party_details,
 	get_party_profile_id,
@@ -48,13 +47,22 @@ class AuthorizeNet(BaseProvider):
 		self.gateway = "Authorize"
 
 	def merchant_auth(self, company):
+		"""
+		Provider-specific method for API authentication
+		"""
 		settings = frappe.get_doc("Electronic Payment Settings", {"company": company})
 		if not settings:
 			frappe.msgprint(_(f"No Electronic Payment Settings found for {company}"))
 		else:
-			api_key_field = "api_key" if settings.provider == self.provider else "sending_api_key"
+			api_key_field = (
+				"authorize_accepting_api_key"
+				if settings.provider == self.provider
+				else "authorize_sending_api_key"
+			)
 			txn_key_field = (
-				"transaction_key" if settings.provider == self.provider else "sending_transaction_key"
+				"authorize_accepting_transaction_key"
+				if settings.provider == self.provider
+				else "authorize_sending_transaction_key"
 			)
 			merchantAuth = apicontractsv1.merchantAuthenticationType()
 			merchantAuth.name = get_decrypted_password(
@@ -64,109 +72,6 @@ class AuthorizeNet(BaseProvider):
 				settings.doctype, settings.name, txn_key_field, raise_exception=False
 			)
 			return merchantAuth
-
-	def process_transaction(self, doc, data, bypass_je_pe_creation=False):
-		mop = data.mode_of_payment.replace("New ", "")
-		party = get_party_details(doc)
-		save_only = data.save_data == "Save payment data only"
-
-		if mop.startswith("Saved"):
-			if data.get("subject_to_credit_limit") and exceeds_credit_limit(doc, data):
-				return {"error": "Credit Limit exceeded for selected Mode of Payment"}
-			if party.doctype == "Customer":
-				response = self.charge_party_profile(doc, data)
-			else:
-				response = self.credit_bank_account(doc, data, bypass_je_pe_creation=bypass_je_pe_creation)
-		elif mop == "Card" and data.get("save_data") == "Charge now":
-			response = self.process_credit_card(doc, data)
-		else:  # charge new Card/ACH, save payment data (temporarily if txn only - payment profile deleted once charge is successful)
-			party_response = self.create_party_profile(doc)
-			if party_response.get("message") == "Success":
-				data.update({"party_profile_id": party_response.get("transaction_id")})
-				pmt_profile_response = self.create_party_payment_profile(doc, data)
-				if pmt_profile_response.get("message") == "Success":
-					pp_doc = pmt_profile_response.get("payment_profile_doc")
-					data.update({"payment_profile_id": pp_doc.payment_profile_id})
-					if save_only:
-						return pmt_profile_response
-					if party.doctype == "Customer":
-						response = self.charge_party_profile(doc, data)
-					else:
-						response = self.credit_bank_account(doc, data)
-				else:  # error creating the customer payment profile
-					return pmt_profile_response
-			else:  # error creating customer profile
-				return party_response
-		return response
-
-	def process_credit_card(self, doc, data):
-		settings = frappe.get_doc("Electronic Payment Settings", {"company": doc.company})
-		endpoint_field = "endpoint" if settings.provider == self.provider else "sending_endpoint"
-		card_number = data.get("card_number")
-		creditCard = apicontractsv1.creditCardType()
-		creditCard.cardNumber = card_number.replace(" ", "")
-		creditCard.expirationDate = data.get("card_expiration_date")
-		creditCard.cardCode = str(data.get("card_cvc"))
-		payment = apicontractsv1.paymentType()
-		payment.creditCard = creditCard
-
-		payment_amount = data.get("amount") or get_payment_amount(doc, data)
-		discount_amount = 0 if data.get("amount") else get_discount_amount(doc, data)
-		if data.get("ppm_name") and not data.get("additional_charges"):
-			data.update({"additional_charges": calculate_payment_method_fees(doc, data)})
-		total_to_charge = flt(
-			payment_amount - discount_amount + data.get("additional_charges", 0),
-			frappe.get_precision(doc.doctype, "grand_total"),
-		)
-
-		transactionrequest = apicontractsv1.transactionRequestType()
-		transactionrequest.transactionType = "refundTransaction"
-		transactionrequest.amount = Decimal(str(total_to_charge))
-		transactionrequest.currencyCode = frappe.defaults.get_global_default("currency")
-		transactionrequest.payment = payment
-
-		createtransactionrequest = apicontractsv1.createTransactionRequest()
-		createtransactionrequest.merchantAuthentication = self.merchant_auth(doc.company)
-		createtransactionrequest.refId = doc.name[:20]  # Authorize.net length constraint
-		createtransactionrequest.transactionRequest = transactionrequest
-
-		createtransactioncontroller = createTransactionController(createtransactionrequest)
-		createtransactioncontroller.setenvironment(settings.get(endpoint_field))
-		createtransactioncontroller.execute()
-
-		response = createtransactioncontroller.getresponse()
-		error_message = ""
-
-		if response is not None:
-			if response.messages.resultCode == "Ok":
-				frappe.db.set_value(
-					doc.doctype,
-					doc.name,
-					"electronic_payment_reference",
-					str(response.transactionResponse.transId),
-				)
-				queue_method_as_admin(
-					process_electronic_payment,
-					doc=doc,
-					data=data,
-					transaction_id=str(response.transactionResponse.transId),
-				)
-				return {
-					"message": "Success",
-					"transaction_id": str(response.transactionResponse.transId),
-				}
-			else:
-				if hasattr(response, "transactionResponse") and hasattr(
-					response.transactionResponse, "errors"
-				):
-					error_message = str(response.transactionResponse.errors.error[0].errorText)
-				else:
-					error_message = str(response.messages.message[0]["text"].text)
-		else:
-			error_message = "No response"
-
-		frappe.log_error(message=frappe.get_traceback(), title=error_message)
-		return {"error": error_message}
 
 	def create_party_profile(self, doc):
 		party = get_party_details(doc)
@@ -192,115 +97,6 @@ class AuthorizeNet(BaseProvider):
 				error_message = str(response.messages.message[0]["text"].text)
 				frappe.log_error(message=frappe.get_traceback(), title=error_message)
 				return {"error": error_message}
-
-	def edit_payment_profile(self, company, electronic_payment_profile_name, data):
-		merchantAuth = self.merchant_auth(company)
-		payment_profile = frappe.get_doc(
-			"Electronic Payment Profile", {"name": electronic_payment_profile_name}
-		)
-
-		payment = apicontractsv1.paymentType()
-		paymentProfile = apicontractsv1.customerPaymentProfileExType()
-		paymentProfile.billTo = apicontractsv1.customerAddressType()
-
-		if payment_profile.payment_type == "Card":
-			creditCard = apicontractsv1.creditCardType()
-			creditCard.cardNumber = data.get("card_number")
-			last4 = data.get("card_number")[-4:]
-			creditCard.expirationDate = data.get("card_expiration_date")
-			creditCard.cardCode = str(data.get("card_cvc"))
-			payment.creditCard = creditCard
-			paymentProfile.billTo.firstName = " ".join(data.get("cardholder_name").split(" ")[0:-1])
-			paymentProfile.billTo.lastName = data.get("cardholder_name").split(" ")[-1]
-		elif payment_profile.payment_type == "ACH":
-			account_number = str(data.get("account_number"))
-			last4 = account_number[-4:]
-			bankAccount = apicontractsv1.bankAccountType()
-			accountType = apicontractsv1.bankAccountTypeEnum
-			bankAccount.accountType = accountType.checking
-			bankAccount.routingNumber = str(data.get("routing_number"))
-			bankAccount.accountNumber = account_number
-			bankAccount.nameOnAccount = data.get("account_holders_name")
-			payment.bankAccount = bankAccount
-			paymentProfile.billTo.firstName = " ".join(data.get("account_holders_name").split(" ")[0:-1])
-			paymentProfile.billTo.lastName = data.get("account_holders_name").split(" ")[-1]
-
-		paymentProfile.payment = payment
-		paymentProfile.customerPaymentProfileId = str(payment_profile.payment_profile_id)
-
-		updateCustomerPaymentProfile = apicontractsv1.updateCustomerPaymentProfileRequest()
-		updateCustomerPaymentProfile.merchantAuthentication = merchantAuth
-		updateCustomerPaymentProfile.paymentProfile = paymentProfile
-		updateCustomerPaymentProfile.customerProfileId = str(payment_profile.party_profile)
-
-		controller = updateCustomerPaymentProfileController(updateCustomerPaymentProfile)
-		controller.execute()
-
-		response = controller.getresponse()
-
-		if response.messages.resultCode == "Ok":
-			payment_profile.reference = (
-				f"**** **** **** {last4}" if payment_profile.payment_type == "Card" else f"*{last4}"
-			)
-			payment_profile.save(ignore_permissions=True)
-			ppm = frappe.get_doc(
-				"Portal Payment Method", {"electronic_payment_profile": payment_profile.name}
-			)
-			ppm.label = f"{payment_profile.payment_type}-{last4}"
-			ppm.default = cint(data.get("default", 0))
-			ppm.electronic_payment_profile = payment_profile.name
-			ppm.save(ignore_permissions=True)
-			return {"message": "Success", "payment_profile_doc": payment_profile}
-		else:
-			error_message = str(response.messages.message[0]["text"].text)
-			frappe.log_error(message=frappe.get_traceback(), title=error_message)
-			return {"error": error_message}
-
-	def get_party_payment_profile(self, company, electronic_payment_profile_name):
-		merchantAuth = self.merchant_auth(company)
-
-		electronic_payment_profile = frappe.get_doc(
-			"Electronic Payment Profile", {"name": electronic_payment_profile_name}
-		)
-		getCustomerPaymentProfile = apicontractsv1.getCustomerPaymentProfileRequest()
-		getCustomerPaymentProfile.merchantAuthentication = merchantAuth
-		getCustomerPaymentProfile.customerProfileId = electronic_payment_profile.party_profile
-		getCustomerPaymentProfile.customerPaymentProfileId = (
-			electronic_payment_profile.payment_profile_id
-		)
-		controller = getCustomerPaymentProfileController(getCustomerPaymentProfile)
-		controller.execute()
-		response = controller.getresponse()
-
-		if response.messages.resultCode != "Ok":
-			error_message = str(response.messages.message[0]["text"].text)
-			frappe.log_error(message=frappe.get_traceback(), title=error_message)
-			return {"error": error_message}
-
-		if electronic_payment_profile.payment_type == "Card":
-			return {
-				"message": "Success",
-				"data": {
-					"first_name": response.paymentProfile.billTo.firstName,
-					"last_name": response.paymentProfile.billTo.lastName,
-					"card_number": response.paymentProfile.payment.creditCard.cardNumber,
-					"expiration_date": response.paymentProfile.payment.creditCard.expirationDate,
-					"card_type": response.paymentProfile.payment.creditCard.cardType,
-				},
-			}
-		elif electronic_payment_profile.payment_type == "ACH":
-			return {
-				"message": "Success",
-				"data": {
-					"first_name": response.paymentProfile.billTo.firstName,
-					"last_name": response.paymentProfile.billTo.lastName,
-					"account_type": response.paymentProfile.payment.bankAccount.accountType,
-					"routing_number": response.paymentProfile.payment.bankAccount.routingNumber,
-					"account_number": response.paymentProfile.payment.bankAccount.accountNumber,
-					"name_on_account": response.paymentProfile.payment.bankAccount.nameOnAccount,
-					"echeck_type": response.paymentProfile.payment.bankAccount.echeckType,
-				},
-			}
 
 	def create_party_payment_profile(self, doc, data):
 		party = get_party_details(doc)
@@ -399,9 +195,246 @@ class AuthorizeNet(BaseProvider):
 			frappe.log_error(message=frappe.get_traceback(), title=error_message)
 			return {"error": error_message}
 
+	def get_party_payment_profile(self, company, electronic_payment_profile_name):
+		merchantAuth = self.merchant_auth(company)
+
+		electronic_payment_profile = frappe.get_doc(
+			"Electronic Payment Profile", {"name": electronic_payment_profile_name}
+		)
+		getCustomerPaymentProfile = apicontractsv1.getCustomerPaymentProfileRequest()
+		getCustomerPaymentProfile.merchantAuthentication = merchantAuth
+		getCustomerPaymentProfile.customerProfileId = electronic_payment_profile.party_profile
+		getCustomerPaymentProfile.customerPaymentProfileId = (
+			electronic_payment_profile.payment_profile_id
+		)
+		controller = getCustomerPaymentProfileController(getCustomerPaymentProfile)
+		controller.execute()
+		response = controller.getresponse()
+
+		if response.messages.resultCode != "Ok":
+			error_message = str(response.messages.message[0]["text"].text)
+			frappe.log_error(message=frappe.get_traceback(), title=error_message)
+			return {"error": error_message}
+
+		if electronic_payment_profile.payment_type == "Card":
+			return {
+				"message": "Success",
+				"data": {
+					"first_name": response.paymentProfile.billTo.firstName,
+					"last_name": response.paymentProfile.billTo.lastName,
+					"card_number": response.paymentProfile.payment.creditCard.cardNumber,
+					"expiration_date": response.paymentProfile.payment.creditCard.expirationDate,
+					"card_type": response.paymentProfile.payment.creditCard.cardType,
+				},
+			}
+		elif electronic_payment_profile.payment_type == "ACH":
+			return {
+				"message": "Success",
+				"data": {
+					"first_name": response.paymentProfile.billTo.firstName,
+					"last_name": response.paymentProfile.billTo.lastName,
+					"account_type": response.paymentProfile.payment.bankAccount.accountType,
+					"routing_number": response.paymentProfile.payment.bankAccount.routingNumber,
+					"account_number": response.paymentProfile.payment.bankAccount.accountNumber,
+					"name_on_account": response.paymentProfile.payment.bankAccount.nameOnAccount,
+					"echeck_type": response.paymentProfile.payment.bankAccount.echeckType,
+				},
+			}
+
+	def edit_payment_profile(self, company, electronic_payment_profile_name, data):
+		merchantAuth = self.merchant_auth(company)
+		payment_profile = frappe.get_doc(
+			"Electronic Payment Profile", {"name": electronic_payment_profile_name}
+		)
+
+		payment = apicontractsv1.paymentType()
+		paymentProfile = apicontractsv1.customerPaymentProfileExType()
+		paymentProfile.billTo = apicontractsv1.customerAddressType()
+
+		if payment_profile.payment_type == "Card":
+			creditCard = apicontractsv1.creditCardType()
+			creditCard.cardNumber = data.get("card_number")
+			last4 = data.get("card_number")[-4:]
+			creditCard.expirationDate = data.get("card_expiration_date")
+			creditCard.cardCode = str(data.get("card_cvc"))
+			payment.creditCard = creditCard
+			paymentProfile.billTo.firstName = " ".join(data.get("cardholder_name").split(" ")[0:-1])
+			paymentProfile.billTo.lastName = data.get("cardholder_name").split(" ")[-1]
+		elif payment_profile.payment_type == "ACH":
+			account_number = str(data.get("account_number"))
+			last4 = account_number[-4:]
+			bankAccount = apicontractsv1.bankAccountType()
+			accountType = apicontractsv1.bankAccountTypeEnum
+			bankAccount.accountType = accountType.checking
+			bankAccount.routingNumber = str(data.get("routing_number"))
+			bankAccount.accountNumber = account_number
+			bankAccount.nameOnAccount = data.get("account_holders_name")
+			payment.bankAccount = bankAccount
+			paymentProfile.billTo.firstName = " ".join(data.get("account_holders_name").split(" ")[0:-1])
+			paymentProfile.billTo.lastName = data.get("account_holders_name").split(" ")[-1]
+
+		paymentProfile.payment = payment
+		paymentProfile.customerPaymentProfileId = str(payment_profile.payment_profile_id)
+
+		updateCustomerPaymentProfile = apicontractsv1.updateCustomerPaymentProfileRequest()
+		updateCustomerPaymentProfile.merchantAuthentication = merchantAuth
+		updateCustomerPaymentProfile.paymentProfile = paymentProfile
+		updateCustomerPaymentProfile.customerProfileId = str(payment_profile.party_profile)
+
+		controller = updateCustomerPaymentProfileController(updateCustomerPaymentProfile)
+		controller.execute()
+
+		response = controller.getresponse()
+
+		if response.messages.resultCode == "Ok":
+			payment_profile.reference = (
+				f"**** **** **** {last4}" if payment_profile.payment_type == "Card" else f"*{last4}"
+			)
+			payment_profile.save(ignore_permissions=True)
+			ppm = frappe.get_doc(
+				"Portal Payment Method", {"electronic_payment_profile": payment_profile.name}
+			)
+			ppm.label = f"{payment_profile.payment_type}-{last4}"
+			ppm.default = cint(data.get("default", 0))
+			ppm.electronic_payment_profile = payment_profile.name
+			ppm.save(ignore_permissions=True)
+			return {"message": "Success", "payment_profile_doc": payment_profile}
+		else:
+			error_message = str(response.messages.message[0]["text"].text)
+			frappe.log_error(message=frappe.get_traceback(), title=error_message)
+			return {"error": error_message}
+
+	def delete_payment_profile(self, company, payment_profile_id):
+		# Delete from ERPNext
+		epp_name, party, customer_profile_id = frappe.get_value(
+			"Electronic Payment Profile",
+			{"payment_profile_id": payment_profile_id},
+			["name", "party", "party_profile"],
+		)
+		pmm_name = frappe.get_value("Portal Payment Method", {"electronic_payment_profile": epp_name})
+
+		if pmm_name:
+			frappe.delete_doc("Portal Payment Method", pmm_name, ignore_permissions=True)
+		frappe.delete_doc("Electronic Payment Profile", epp_name, ignore_permissions=True)
+
+		# Delete from API
+		merchantAuth = self.merchant_auth(company)
+		deleteCustomerPaymentProfile = apicontractsv1.deleteCustomerPaymentProfileRequest()
+		deleteCustomerPaymentProfile.merchantAuthentication = merchantAuth
+		deleteCustomerPaymentProfile.customerProfileId = str(customer_profile_id)
+		deleteCustomerPaymentProfile.customerPaymentProfileId = str(payment_profile_id)
+
+		controller = deleteCustomerPaymentProfileController(deleteCustomerPaymentProfile)
+		controller.execute()
+		response = controller.getresponse()
+
+		if response is None or (hasattr(response, "messages") and response.messages.resultCode != "Ok"):
+			frappe.log_error(
+				message=frappe.get_traceback(),
+				title=f"Error deleting payment profile attached to {party}.",
+			)
+		else:
+			return {"message": "Success"}
+
+	def delete_party_profile(self, company, party, party_profile_id):
+		merchantAuth = self.merchant_auth(company)
+		deleteCustomerProfile = apicontractsv1.deleteCustomerProfileRequest()
+		deleteCustomerProfile.merchantAuthentication = merchantAuth
+		deleteCustomerProfile.customerProfileId = party_profile_id
+
+		controller = deleteCustomerProfileController(deleteCustomerProfile)
+		controller.execute()
+
+		response = controller.getresponse()
+
+		if response is None or (hasattr(response, "messages") and response.messages.resultCode != "Ok"):
+			frappe.log_error(
+				message=frappe.get_traceback(),
+				title=f"Error deleting profile for {party}",
+			)
+		else:
+			return {"message": "Success"}
+
+	def process_credit_card(self, doc, data):
+		settings = frappe.get_doc("Electronic Payment Settings", {"company": doc.company})
+		endpoint_field = (
+			"authorize_accepting_endpoint"
+			if settings.provider == self.provider
+			else "authorize_sending_endpoint"
+		)
+		card_number = data.get("card_number")
+		creditCard = apicontractsv1.creditCardType()
+		creditCard.cardNumber = card_number.replace(" ", "")
+		creditCard.expirationDate = data.get("card_expiration_date")
+		creditCard.cardCode = str(data.get("card_cvc"))
+		payment = apicontractsv1.paymentType()
+		payment.creditCard = creditCard
+
+		payment_amount = data.get("amount") or get_payment_amount(doc, data)
+		discount_amount = 0 if data.get("amount") else get_discount_amount(doc, data)
+		if data.get("ppm_name") and not data.get("additional_charges"):
+			data.update({"additional_charges": calculate_payment_method_fees(doc, data)})
+		total_to_charge = flt(
+			payment_amount - discount_amount + data.get("additional_charges", 0),
+			frappe.get_precision(doc.doctype, "grand_total"),
+		)
+
+		transactionrequest = apicontractsv1.transactionRequestType()
+		transactionrequest.transactionType = "refundTransaction"
+		transactionrequest.amount = Decimal(str(total_to_charge))
+		transactionrequest.currencyCode = frappe.defaults.get_global_default("currency")
+		transactionrequest.payment = payment
+
+		createtransactionrequest = apicontractsv1.createTransactionRequest()
+		createtransactionrequest.merchantAuthentication = self.merchant_auth(doc.company)
+		createtransactionrequest.refId = doc.name[:20]  # Authorize.net length constraint
+		createtransactionrequest.transactionRequest = transactionrequest
+
+		createtransactioncontroller = createTransactionController(createtransactionrequest)
+		createtransactioncontroller.setenvironment(settings.get(endpoint_field))
+		createtransactioncontroller.execute()
+
+		response = createtransactioncontroller.getresponse()
+		error_message = ""
+
+		if response is not None:
+			if response.messages.resultCode == "Ok":
+				frappe.db.set_value(
+					doc.doctype,
+					doc.name,
+					"electronic_payment_reference",
+					str(response.transactionResponse.transId),
+				)
+				queue_method_as_admin(
+					process_electronic_payment,
+					doc=doc,
+					data=data,
+					transaction_id=str(response.transactionResponse.transId),
+				)
+				return {
+					"message": "Success",
+					"transaction_id": str(response.transactionResponse.transId),
+				}
+			else:
+				if hasattr(response, "transactionResponse") and hasattr(
+					response.transactionResponse, "errors"
+				):
+					error_message = str(response.transactionResponse.errors.error[0].errorText)
+				else:
+					error_message = str(response.messages.message[0]["text"].text)
+		else:
+			error_message = "No response"
+
+		frappe.log_error(message=frappe.get_traceback(), title=error_message)
+		return {"error": error_message}
+
 	def charge_party_profile(self, doc, data):
 		settings = frappe.get_doc("Electronic Payment Settings", {"company": doc.company})
-		endpoint_field = "endpoint" if settings.provider == self.provider else "sending_endpoint"
+		endpoint_field = (
+			"authorize_accepting_endpoint"
+			if settings.provider == self.provider
+			else "authorize_sending_endpoint"
+		)
 		party = get_party_details(doc)
 		if not data.get("party_profile_id"):
 			party_profile_id = get_party_profile_id(party.name, doc.company, self.provider)
@@ -510,7 +543,7 @@ class AuthorizeNet(BaseProvider):
 
 	def credit_bank_account(self, doc, data, bypass_je_pe_creation=False):
 		"""
-		Sends a payment to specified party profile in the data dict.
+		Provider-specific method - sends a payment to specified party profile in the data dict
 
 		:param doc: typically expects a PO or PI doc. If calling from Check Run, can pass a
 		frappe._dict with company, supplier, supplier_name, and currency (and the data dict must
@@ -531,7 +564,11 @@ class AuthorizeNet(BaseProvider):
 		"""
 		merchantAuth = self.merchant_auth(doc.company)
 		settings = frappe.get_doc("Electronic Payment Settings", {"company": doc.company})
-		endpoint_field = "endpoint" if settings.provider == self.provider else "sending_endpoint"
+		endpoint_field = (
+			"authorize_accepting_endpoint"
+			if settings.provider == self.provider
+			else "authorize_sending_endpoint"
+		)
 		party = get_party_details(doc)
 
 		if not data.get("party_profile_id"):
@@ -619,7 +656,11 @@ class AuthorizeNet(BaseProvider):
 		"""
 		merchantAuth = self.merchant_auth(doc.company)
 		settings = frappe.get_doc("Electronic Payment Settings", {"company": doc.company})
-		endpoint_field = "endpoint" if settings.provider == self.provider else "sending_endpoint"
+		endpoint_field = (
+			"authorize_accepting_endpoint"
+			if settings.provider == self.provider
+			else "authorize_sending_endpoint"
+		)
 		orig_transaction_id = doc.electronic_payment_reference
 		amount = data.get("amount")
 
@@ -708,7 +749,11 @@ class AuthorizeNet(BaseProvider):
 	def void_transaction(self, doc, data):
 		merchantAuth = self.merchant_auth(doc.company)
 		settings = frappe.get_doc("Electronic Payment Settings", {"company": doc.company})
-		endpoint_field = "endpoint" if settings.provider == self.provider else "sending_endpoint"
+		endpoint_field = (
+			"authorize_accepting_endpoint"
+			if settings.provider == self.provider
+			else "authorize_sending_endpoint"
+		)
 		orig_transaction_id = doc.electronic_payment_reference
 
 		transactionrequest = apicontractsv1.transactionRequestType()
@@ -820,57 +865,6 @@ class AuthorizeNet(BaseProvider):
 
 		frappe.log_error(message=frappe.get_traceback(), title=error_message)
 		return {"error": error_message}
-
-	def delete_payment_profile(self, company, payment_profile_id):
-		# Delete from ERPNext
-		epp_name, party, customer_profile_id = frappe.get_value(
-			"Electronic Payment Profile",
-			{"payment_profile_id": payment_profile_id},
-			["name", "party", "party_profile"],
-		)
-		pmm_name = frappe.get_value("Portal Payment Method", {"electronic_payment_profile": epp_name})
-
-		if pmm_name:
-			frappe.delete_doc("Portal Payment Method", pmm_name, ignore_permissions=True)
-		frappe.delete_doc("Electronic Payment Profile", epp_name, ignore_permissions=True)
-
-		# Delete from API
-		merchantAuth = self.merchant_auth(company)
-		deleteCustomerPaymentProfile = apicontractsv1.deleteCustomerPaymentProfileRequest()
-		deleteCustomerPaymentProfile.merchantAuthentication = merchantAuth
-		deleteCustomerPaymentProfile.customerProfileId = str(customer_profile_id)
-		deleteCustomerPaymentProfile.customerPaymentProfileId = str(payment_profile_id)
-
-		controller = deleteCustomerPaymentProfileController(deleteCustomerPaymentProfile)
-		controller.execute()
-		response = controller.getresponse()
-
-		if response is None or (hasattr(response, "messages") and response.messages.resultCode != "Ok"):
-			frappe.log_error(
-				message=frappe.get_traceback(),
-				title=f"Error deleting payment profile attached to {party}.",
-			)
-		else:
-			return {"message": "Success"}
-
-	def delete_party_profile(self, company, party, party_profile_id):
-		merchantAuth = self.merchant_auth(company)
-		deleteCustomerProfile = apicontractsv1.deleteCustomerProfileRequest()
-		deleteCustomerProfile.merchantAuthentication = merchantAuth
-		deleteCustomerProfile.customerProfileId = party_profile_id
-
-		controller = deleteCustomerProfileController(deleteCustomerProfile)
-		controller.execute()
-
-		response = controller.getresponse()
-
-		if response is None or (hasattr(response, "messages") and response.messages.resultCode != "Ok"):
-			frappe.log_error(
-				message=frappe.get_traceback(),
-				title=f"Error deleting profile for {party}",
-			)
-		else:
-			return {"message": "Success"}
 
 
 def fetch_authorize_transactions(settings):

--- a/electronic_payments/electronic_payments/doctype/electronic_payment_settings/authorize.py
+++ b/electronic_payments/electronic_payments/doctype/electronic_payment_settings/authorize.py
@@ -23,6 +23,9 @@ from frappe.utils import cint
 from frappe.utils.data import flt, today
 from frappe.utils.password import get_decrypted_password
 
+from electronic_payments.electronic_payments.doctype.electronic_payment_settings.base import (
+	BaseProvider,
+)
 from electronic_payments.electronic_payments.doctype.electronic_payment_settings.common import (
 	calculate_payment_method_fees,
 	exceeds_credit_limit,
@@ -35,15 +38,23 @@ from electronic_payments.electronic_payments.doctype.electronic_payment_settings
 )
 
 
-class AuthorizeNet:
+class AuthorizeNet(BaseProvider):
+	def __init__(self):
+		"""
+		self.provider value should match the selection text in Electronic Payment Settings
+		self.gateway value should match the selection text in Electronic Payment Profile
+		"""
+		self.provider = "Authorize.net"
+		self.gateway = "Authorize"
+
 	def merchant_auth(self, company):
 		settings = frappe.get_doc("Electronic Payment Settings", {"company": company})
 		if not settings:
 			frappe.msgprint(_(f"No Electronic Payment Settings found for {company}"))
 		else:
-			api_key_field = "api_key" if settings.provider == "Authorize.net" else "sending_api_key"
+			api_key_field = "api_key" if settings.provider == self.provider else "sending_api_key"
 			txn_key_field = (
-				"transaction_key" if settings.provider == "Authorize.net" else "sending_transaction_key"
+				"transaction_key" if settings.provider == self.provider else "sending_transaction_key"
 			)
 			merchantAuth = apicontractsv1.merchantAuthenticationType()
 			merchantAuth.name = get_decrypted_password(
@@ -90,7 +101,7 @@ class AuthorizeNet:
 
 	def process_credit_card(self, doc, data):
 		settings = frappe.get_doc("Electronic Payment Settings", {"company": doc.company})
-		endpoint_field = "endpoint" if settings.provider == "Authorize.net" else "sending_endpoint"
+		endpoint_field = "endpoint" if settings.provider == self.provider else "sending_endpoint"
 		card_number = data.get("card_number")
 		creditCard = apicontractsv1.creditCardType()
 		creditCard.cardNumber = card_number.replace(" ", "")
@@ -159,7 +170,7 @@ class AuthorizeNet:
 
 	def create_party_profile(self, doc):
 		party = get_party_details(doc)
-		existing_party_id = get_party_profile_id(party.name, doc.company, "Authorize.net")
+		existing_party_id = get_party_profile_id(party.name, doc.company, self.provider)
 		if existing_party_id:
 			return {"message": "Success", "transaction_id": existing_party_id}
 		else:
@@ -183,7 +194,7 @@ class AuthorizeNet:
 				frappe.log_error(message=frappe.get_traceback(), title=error_message)
 				return {"error": error_message}
 
-	def edit_customer_payment_profile(self, company, electronic_payment_profile_name, data):
+	def edit_payment_profile(self, company, electronic_payment_profile_name, data):
 		merchantAuth = self.merchant_auth(company)
 		payment_profile = frappe.get_doc(
 			"Electronic Payment Profile", {"name": electronic_payment_profile_name}
@@ -296,7 +307,7 @@ class AuthorizeNet:
 		party = get_party_details(doc)
 
 		if not data.get("party_profile_id"):
-			party_profile_id = get_party_profile_id(party.name, doc.company, "Authorize.net")
+			party_profile_id = get_party_profile_id(party.name, doc.company, self.provider)
 		else:
 			party_profile_id = data.get("party_profile_id")
 
@@ -356,7 +367,7 @@ class AuthorizeNet:
 			payment_profile.party_type = party.doctype
 			payment_profile.party = party.name
 			payment_profile.payment_type = mop
-			payment_profile.payment_gateway = "Authorize"
+			payment_profile.payment_gateway = self.gateway
 			payment_profile.reference = f"**** **** **** {last4}" if mop == "Card" else f"*{last4}"
 			payment_profile.payment_profile_id = str(response.customerPaymentProfileId)
 			payment_profile.party_profile = str(party_profile_id)
@@ -366,7 +377,7 @@ class AuthorizeNet:
 
 			if payment_profile.retain and settings.create_ppm:
 				mop_field = (
-					"mode_of_payment" if settings.provider == "Authorize.net" else "sending_mode_of_payment"
+					"mode_of_payment" if settings.provider == self.provider else "sending_mode_of_payment"
 				)
 				ppm = frappe.new_doc("Portal Payment Method")
 				ppm.mode_of_payment = settings.get(mop_field)
@@ -391,10 +402,10 @@ class AuthorizeNet:
 
 	def charge_party_profile(self, doc, data):
 		settings = frappe.get_doc("Electronic Payment Settings", {"company": doc.company})
-		endpoint_field = "endpoint" if settings.provider == "Authorize.net" else "sending_endpoint"
+		endpoint_field = "endpoint" if settings.provider == self.provider else "sending_endpoint"
 		party = get_party_details(doc)
 		if not data.get("party_profile_id"):
-			party_profile_id = get_party_profile_id(party.name, doc.company, "Authorize.net")
+			party_profile_id = get_party_profile_id(party.name, doc.company, self.provider)
 		else:
 			party_profile_id = data.get("party_profile_id")
 
@@ -495,6 +506,9 @@ class AuthorizeNet:
 		frappe.log_error(message=frappe.get_traceback(), title=error_message)
 		return {"error": error_message}
 
+	def create_transfer_to_party_profile(self, doc, data, bypass_je_pe_creation=False):
+		return self.credit_bank_account(doc, data, bypass_je_pe_creation=bypass_je_pe_creation)
+
 	def credit_bank_account(self, doc, data, bypass_je_pe_creation=False):
 		"""
 		Sends a payment to specified party profile in the data dict.
@@ -518,11 +532,11 @@ class AuthorizeNet:
 		"""
 		merchantAuth = self.merchant_auth(doc.company)
 		settings = frappe.get_doc("Electronic Payment Settings", {"company": doc.company})
-		endpoint_field = "endpoint" if settings.provider == "Authorize.net" else "sending_endpoint"
+		endpoint_field = "endpoint" if settings.provider == self.provider else "sending_endpoint"
 		party = get_party_details(doc)
 
 		if not data.get("party_profile_id"):
-			party_profile_id = get_party_profile_id(party.name, doc.company, "Authorize.net")
+			party_profile_id = get_party_profile_id(party.name, doc.company, self.provider)
 		else:
 			party_profile_id = data.get("party_profile_id")
 
@@ -606,7 +620,7 @@ class AuthorizeNet:
 		"""
 		merchantAuth = self.merchant_auth(doc.company)
 		settings = frappe.get_doc("Electronic Payment Settings", {"company": doc.company})
-		endpoint_field = "endpoint" if settings.provider == "Authorize.net" else "sending_endpoint"
+		endpoint_field = "endpoint" if settings.provider == self.provider else "sending_endpoint"
 		orig_transaction_id = doc.electronic_payment_reference
 		amount = data.get("amount")
 
@@ -695,7 +709,7 @@ class AuthorizeNet:
 	def void_transaction(self, doc, data):
 		merchantAuth = self.merchant_auth(doc.company)
 		settings = frappe.get_doc("Electronic Payment Settings", {"company": doc.company})
-		endpoint_field = "endpoint" if settings.provider == "Authorize.net" else "sending_endpoint"
+		endpoint_field = "endpoint" if settings.provider == self.provider else "sending_endpoint"
 		orig_transaction_id = doc.electronic_payment_reference
 
 		transactionrequest = apicontractsv1.transactionRequestType()

--- a/electronic_payments/electronic_payments/doctype/electronic_payment_settings/base.py
+++ b/electronic_payments/electronic_payments/doctype/electronic_payment_settings/base.py
@@ -1,0 +1,308 @@
+# Copyright (c) 2025, AgriTheory and contributors
+# For license information, please see license.txt
+
+
+from electronic_payments.electronic_payments.doctype.electronic_payment_settings.common import (
+	exceeds_credit_limit,
+	get_party_details,
+	get_party_profile_id,
+)
+
+
+class BaseProvider:
+	"""
+	Base class for all payment providers. Code expects that the child provider-specific class
+	implement their own version for any method below that raises a `NotImplementedError`.
+
+	For all methods:
+
+	:param doc: may be a Sales Order, Sales Invoice, Purchase Order, or Purchase Invoice. When
+	method is called from Customer or Supplier page, or from the portal (Customer or Supplier self
+	-service), then it can be a frappe._dict with some/all of the following keys (depending on
+	context): "company", either "customer" or "supplier" (set to the party's name), "doctype" (set
+	to "Sales" or "Purchase"), and "currency"
+	:param data: a dict object containing the necessary data to make an API call. This may be to
+	create or update a payment method with the provider or accept/send a payment against an
+	existing payment method. The required data to create or update a payment method will depend on
+	the provider. To accept or send a payment, data must include the "payment_profile_id", then it
+	can optionally include "amount" (to override calculated amount), "payment_term" (to
+	calculate payment total and discounts), "ppm_name" (to calculate fees configured for that
+	portal payment method), or "subject_to_credit_limit" (a Boolean value)
+	"""
+
+	def process_transaction(self, doc, data, bypass_je_pe_creation=False):
+		"""
+		Processes either accepting or sending a payment via the provider - override this method if
+		the provider's payment workflow doesn't fit this pattern
+
+		:param bypass_je_pe_creation: bool; default is False. If True, will not queue method that
+		creates a Journal Entry or Payment Entry following a successful API response - used when
+		method is called from a place such as Check Run, where that process is already creating a
+		Payment Entry
+		"""
+		mop = data.mode_of_payment.replace("New ", "")
+		party = get_party_details(doc)
+		save_only = data.save_data == "Save payment data only"
+
+		if mop.startswith("Saved"):
+			# check against credit limit, if applicable
+			if data.get("subject_to_credit_limit") and exceeds_credit_limit(doc, data):
+				return {"error": "Credit Limit exceeded for selected Mode of Payment"}
+			# accept from or pay to the saved payment method
+			if party.doctype == "Customer":
+				response = self.charge_party_profile(doc, data)
+			else:
+				response = self.create_transfer_to_party_profile(
+					doc, data, bypass_je_pe_creation=bypass_je_pe_creation
+				)
+		elif mop == "Card" and data.get("save_data") == "Charge now":
+			response = self.process_credit_card(doc, data)
+		else:  # new mode of payment
+			# find party profile, if used by provider
+			party_response = self.get_or_create_party_profile(doc)
+			if party_response.get("message") == "Success":
+				data.update({"party_profile_id": party_response.get("transaction_id")})
+				# creates payment method with provider, saves ID (temporarily if txn only - payment profile deleted once charge is successful)
+				pmt_profile_response = self.create_party_payment_profile(doc, data)
+				if pmt_profile_response.get("message") == "Success":
+					pp_doc = pmt_profile_response.get("payment_profile_doc")
+					data.update({"payment_profile_id": pp_doc.payment_profile_id})
+					if save_only:
+						return pmt_profile_response
+					# charge or transfers to payment profile
+					if party.doctype == "Customer":
+						response = self.charge_party_profile(doc, data)
+					else:
+						response = self.create_transfer_to_party_profile(
+							doc, data, bypass_je_pe_creation=bypass_je_pe_creation
+						)
+				else:  # error creating the payment profile
+					return pmt_profile_response
+			else:  # error getting / creating party profile
+				return party_response
+		return response
+
+	def get_or_create_party_profile(self, doc):
+		"""
+		Collects the party's profile ID with the provider
+		"""
+		party = get_party_details(doc)
+		existing_party_id = get_party_profile_id(party.name, doc.company, self.provider)
+		if existing_party_id:
+			return {"message": "Success", "transaction_id": existing_party_id}
+		else:
+			party_profile_resp = self.create_party_profile(doc)
+			return party_profile_resp
+
+	def create_party_profile(self, doc):
+		"""
+		Implement in the provider class - creates a profile of the party with the provider
+
+		If this functionality isn't supported or not required in provider's payment flow:
+		- return {"message": "Success", "transaction_id": None}
+
+		Successful API call:
+		- return {"message": "Success", "transaction_id": str(party_profile_id)}
+
+		Unsuccessful API call / Error:
+		- return {"error": error_message}
+		"""
+		raise NotImplementedError
+
+	def create_party_payment_profile(self, doc, data):
+		"""
+		Implement in the provider class - creates a payment method for the party with the provider
+
+		If the provider doesn't support the "mode_of_payment" given in `data` dict:
+		- return {"error": _("Mode of Payment not supported")}
+
+		Successful API call:
+		- create an Electronic Payment Profile (payment_profile in return statement) in ERPNext
+		  and a Portal Payment Method, depending on that setting in Electronic Payment Settings
+		- return {"message": "Success", "payment_profile_doc": payment_profile}
+
+		Unsuccessful API call / Error:
+		- return {"error": error_message}
+		"""
+		raise NotImplementedError
+
+	def get_party_payment_profile(self, company, electronic_payment_profile_name):
+		"""
+		Implement in the provider class - gets payment details from provider for an Electronic
+		Payment Profile (called from the Portal to edit a payment method)
+
+		:param company: str; company in ERPNext (to get correct Electronic Payment Settings doc)
+		:param electronic_payment_profile_name: str; name of the Electronic Payment Profile doc
+		in ERPNext for a payment method
+
+		Successful API call:
+		- return {"message": "Success", "data": {payment method details}}
+
+		Unsuccessful API call / Error:
+		- the portal function calling this will raise a Permission Error
+		"""
+		return NotImplementedError
+
+	def edit_payment_profile(self, company, electronic_payment_profile_name, data):
+		"""
+		Implement in the provider class - edits a payment method at the provider and in ERPNext
+
+		:param company: str; company in ERPNext (to get correct Electronic Payment Settings doc)
+		:param electronic_payment_profile_name: str; name of the Electronic Payment Profile doc
+		in ERPNext for a payment method
+		:param data: dict with details to update the payment method with the provider
+
+		If this functionality isn't supported by the provider:
+		- return {"error": reason why not support / recommended action}
+
+		Successful API call:
+		- edit the Electronic Payment Profile and Portal Payment Methods in ERPNext that are
+		  attached to the payment method. For sending payment providers, this may include both
+		  Wire and ACH methods
+		- return {"message": "Success", "payment_profile_doc": payment_profile} where
+		  payment_profile is the associated Electronic Payment Profile doc in ERPNext
+
+		Unsuccessful API call / Error:
+		- return {"error": error_message}
+		"""
+		return NotImplementedError
+
+	def delete_payment_profile(self, company, payment_profile_id):
+		"""
+		Implement in the provider class - deletes a payment profile from the API and ERPNext
+
+		If this functionality isn't supported by the provider:
+		- return {"error": _("Not supported.")}
+
+		Successful API call:
+		- collect all Electronic Payment Profile docs associated with the payment_profile_id
+		  (there may be both an ACH and Wire mode of payment with same ID for some providers)
+		- delete the Electronic Payment Profile and Portal Payment Method docs from ERPNext
+		- return {"message": "Success"}
+
+		Unsuccessful API call / Error:
+		- call frappe.log_error with details
+		"""
+		return NotImplementedError
+
+	def delete_party_profile(self, company, party, party_profile_id):
+		"""
+		Implement in the provider class - deletes a party profile with the provider
+
+		If this functionality isn't used or supported by the provider:
+		- return {"message": "Success"}
+
+		Successful API call:
+		- return {"message": "Success"}
+
+		Unsuccessful API call / Error:
+		- call frappe.log_error with details
+		"""
+		return NotImplementedError
+
+	def charge_party_profile(self, doc, data):
+		"""
+		Implement in the provider class - for accepting a payment from an existing party's profile
+
+		If this functionality isn't supported by the provider:
+		- return {"error": _("Not supported.")}
+
+		Successful API call:
+		- save the transaction ID to doc's electronic_payment_reference field
+		- delete the payment profile from ERPNext if retain isn't checked in EPP doc
+		- run common.py's process_electronic_payment via queue_method_as_admin
+		- return {"message": "Success", "transaction_id": str(transaction_id)}
+
+		Unsuccessful API call / Error:
+		- return {"error": error_message}
+		"""
+		raise NotImplementedError
+
+	def create_transfer_to_party_profile(self, doc, data, bypass_je_pe_creation=False):
+		"""
+		Implement in the provider class - for sending a payment to an existing party's profile
+
+		If this functionality isn't supported by the provider:
+		- return {"error": _("Not supported.")}
+
+		Successful API call:
+		- save the transaction ID to doc's electronic_payment_reference field
+		- delete the payment profile from ERPNext if retain isn't checked in EPP doc
+		- run common.py's process_electronic_payment via queue_method_as_admin if
+		  bypass_je_pe_creation is False (flag is used when called from Check Run)
+		- return {"message": "Success", "transaction_id": str(transaction_id)}
+
+		Unsuccessful API call / Error:
+		- return {"error": error_message}
+		"""
+		raise NotImplementedError
+
+	def process_credit_card(self, doc, data):
+		"""
+		Implement in the provider class - for a one-time charge of a credit card (not saved / not
+		associated with a party profile)
+
+		If this functionality isn't supported by the provider:
+		- return {"error": _("Not supported.")}
+
+		Successful API call:
+		- save the transaction ID to doc's electronic_payment_reference field
+		- run common.py's process_electronic_payment via queue_method_as_admin
+		- return {"message": "Success", "transaction_id": str(transaction_id)}
+
+		Unsuccessful API call / Error:
+		- return {"error": error_message}
+		"""
+		raise NotImplementedError
+
+	def refund_transaction(self, doc, data):
+		"""
+		Implement in the provider class - refunds a transaction
+
+		If this functionality isn't supported by the provider:
+		- return {"error": _("Not supported.")}
+
+		Successful API call:
+		- handle the refund in ERPNext
+		- return {"message": "Success", "transaction_id": str(transaction_id)}
+
+		Unsuccessful API call / Error:
+		- return {"error": error_message}
+		"""
+		raise NotImplementedError
+
+	def void_transaction(self, doc, data):
+		"""
+		Implement in the provider class - voids an unsettled transaction
+
+		If this functionality isn't supported by the provider:
+		- return {"error": _("Not supported.")}
+
+		Successful API call:
+		- handle the voided transaction in ERPNext
+		- return {"message": "Success", "transaction_id": str(transaction_id)}
+
+		Unsuccessful API call / Error:
+		- return {"error": error_message}
+		"""
+		return NotImplementedError
+
+	def get_transaction_details(self, company, transaction_id):
+		"""
+		Implement in the provider class - gets the payment details for a given transaction ID.
+		Supports refund_transaction for certain providers
+
+		:param company: str; company in ERPNext (to get correct Electronic Payment Settings doc)
+		:param transaction_id: str; provider's ID for the transaction
+
+		If this functionality isn't supported by the provider:
+		- return {"error": _("Not supported.")}
+
+		Successful API call:
+		- return {"message": "Success", "payment_details": payment_dict} where payment_dict has
+		  select payment details for the given transaction
+
+		Unsuccessful API call / Error:
+		- return {"error": error_message}
+		"""
+		return NotImplementedError

--- a/electronic_payments/electronic_payments/doctype/electronic_payment_settings/base.py
+++ b/electronic_payments/electronic_payments/doctype/electronic_payment_settings/base.py
@@ -11,7 +11,7 @@ from electronic_payments.electronic_payments.doctype.electronic_payment_settings
 
 class BaseProvider:
 	"""
-	Base class for all payment providers. Code expects that the child provider-specific class
+	Base class for all payment providers. Code expects that the child provider-specific classes
 	implement their own version for any method below that raises a `NotImplementedError`.
 
 	For all methods:
@@ -19,15 +19,29 @@ class BaseProvider:
 	:param doc: may be a Sales Order, Sales Invoice, Purchase Order, or Purchase Invoice. When
 	method is called from Customer or Supplier page, or from the portal (Customer or Supplier self
 	-service), then it can be a frappe._dict with some/all of the following keys (depending on
-	context): "company", either "customer" or "supplier" (set to the party's name), "doctype" (set
-	to "Sales" or "Purchase"), and "currency"
+	context):
+	    {
+	            "company": company in ERPNext (to collect the right Electronic Payment Settings),
+	                "customer" or "supplier": the name of a Customer or Supplier doc in ERPNext,
+	                "doctype": "Sales" or "Purchase" (determines the accepting or sending provider/keys),
+	                "currency": currency code signifier in ERPNext,
+	        }
+
 	:param data: a dict object containing the necessary data to make an API call. This may be to
-	create or update a payment method with the provider or accept/send a payment against an
+	create or update a payment method with the provider or to accept/send a payment against an
 	existing payment method. The required data to create or update a payment method will depend on
-	the provider. To accept or send a payment, data must include the "payment_profile_id", then it
-	can optionally include "amount" (to override calculated amount), "payment_term" (to
-	calculate payment total and discounts), "ppm_name" (to calculate fees configured for that
-	portal payment method), or "subject_to_credit_limit" (a Boolean value)
+	what the provider needs in their API calls. To accept or send a payment:
+	    {
+	            # Required:
+	            "payment_profile_id": ID of a payment method with the provider,
+
+	                # Optional:
+	    "amount": amount to charge or pay (if not provided, looks for a payment term or the
+	                doc's outstanding amount),
+	                "payment_term": name of a Payment Term in ERPNext associated with the doc,
+	                "ppm_name": name of a Portal Payment Method in ERPNext (to calculate configured fees),
+	                "subject_to_credit_limit": 1/True or 0/False/not provided,
+	        }
 	"""
 
 	def process_transaction(self, doc, data, bypass_je_pe_creation=False):
@@ -44,42 +58,40 @@ class BaseProvider:
 		party = get_party_details(doc)
 		save_only = data.save_data == "Save payment data only"
 
-		if mop.startswith("Saved"):
-			# check against credit limit, if applicable
-			if data.get("subject_to_credit_limit") and exceeds_credit_limit(doc, data):
-				return {"error": "Credit Limit exceeded for selected Mode of Payment"}
-			# accept from or pay to the saved payment method
-			if party.doctype == "Customer":
-				response = self.charge_party_profile(doc, data)
-			else:
-				response = self.create_transfer_to_party_profile(
-					doc, data, bypass_je_pe_creation=bypass_je_pe_creation
-				)
-		elif mop == "Card" and data.get("save_data") == "Charge now":
+		if mop == "Card" and data.get("save_data") == "Charge now":
 			response = self.process_credit_card(doc, data)
-		else:  # new mode of payment
-			# find party profile, if used by provider
+
+		if not mop.startswith("Saved"):  # new payment method
+			# find party profile (if used by provider)
 			party_response = self.get_or_create_party_profile(doc)
 			if party_response.get("message") == "Success":
 				data.update({"party_profile_id": party_response.get("transaction_id")})
-				# creates payment method with provider, saves ID (temporarily if txn only - payment profile deleted once charge is successful)
+
+				# create payment method with provider, save ID to data
 				pmt_profile_response = self.create_party_payment_profile(doc, data)
 				if pmt_profile_response.get("message") == "Success":
 					pp_doc = pmt_profile_response.get("payment_profile_doc")
 					data.update({"payment_profile_id": pp_doc.payment_profile_id})
 					if save_only:
 						return pmt_profile_response
-					# charge or transfers to payment profile
-					if party.doctype == "Customer":
-						response = self.charge_party_profile(doc, data)
-					else:
-						response = self.create_transfer_to_party_profile(
-							doc, data, bypass_je_pe_creation=bypass_je_pe_creation
-						)
 				else:  # error creating the payment profile
 					return pmt_profile_response
 			else:  # error getting / creating party profile
 				return party_response
+		elif (  # handle a saved method where amount exceeds credit limit
+			mop.startswith("Saved")
+			and data.get("subject_to_credit_limit")
+			and exceeds_credit_limit(doc, data)
+		):
+			return {"error": "Credit Limit exceeded for selected Mode of Payment"}
+
+		# charge or send transfer to the saved or newly created payment method
+		if party.doctype == "Customer":
+			response = self.charge_party_profile(doc, data)
+		else:
+			response = self.create_transfer_to_party_profile(
+				doc, data, bypass_je_pe_creation=bypass_je_pe_creation
+			)
 		return response
 
 	def get_or_create_party_profile(self, doc):
@@ -200,6 +212,24 @@ class BaseProvider:
 		"""
 		return NotImplementedError
 
+	def process_credit_card(self, doc, data):
+		"""
+		Implement in the provider class - for a one-time charge of a credit card (not saved / not
+		associated with a party profile)
+
+		If this functionality isn't supported by the provider:
+		- return {"error": _("Not supported.")}
+
+		Successful API call:
+		- save the transaction ID to doc's electronic_payment_reference field
+		- run common.py's process_electronic_payment via queue_method_as_admin
+		- return {"message": "Success", "transaction_id": str(transaction_id)}
+
+		Unsuccessful API call / Error:
+		- return {"error": error_message}
+		"""
+		raise NotImplementedError
+
 	def charge_party_profile(self, doc, data):
 		"""
 		Implement in the provider class - for accepting a payment from an existing party's profile
@@ -230,24 +260,6 @@ class BaseProvider:
 		- delete the payment profile from ERPNext if retain isn't checked in EPP doc
 		- run common.py's process_electronic_payment via queue_method_as_admin if
 		  bypass_je_pe_creation is False (flag is used when called from Check Run)
-		- return {"message": "Success", "transaction_id": str(transaction_id)}
-
-		Unsuccessful API call / Error:
-		- return {"error": error_message}
-		"""
-		raise NotImplementedError
-
-	def process_credit_card(self, doc, data):
-		"""
-		Implement in the provider class - for a one-time charge of a credit card (not saved / not
-		associated with a party profile)
-
-		If this functionality isn't supported by the provider:
-		- return {"error": _("Not supported.")}
-
-		Successful API call:
-		- save the transaction ID to doc's electronic_payment_reference field
-		- run common.py's process_electronic_payment via queue_method_as_admin
 		- return {"message": "Success", "transaction_id": str(transaction_id)}
 
 		Unsuccessful API call / Error:

--- a/electronic_payments/electronic_payments/doctype/electronic_payment_settings/electronic_payment_settings.json
+++ b/electronic_payments/electronic_payments/doctype/electronic_payment_settings/electronic_payment_settings.json
@@ -6,17 +6,18 @@
 	"editable_grid": 1,
 	"engine": "InnoDB",
 	"field_order": [
-		"accepting_payments_tab",
+		"general_tab",
 		"company",
 		"create_ppm",
+		"accepting_payments_tab",
 		"enable_accepting",
-		"accepting_config_section",
 		"provider",
-		"ref_id",
-		"column_break_zyrs",
-		"endpoint",
-		"api_key",
-		"transaction_key",
+		"authorizenet_accepting_configuration_section",
+		"authorize_accepting_endpoint",
+		"authorize_accepting_api_key",
+		"authorize_accepting_transaction_key",
+		"stripe_accepting_configuration_section",
+		"stripe_accepting_api_key",
 		"section_break_5",
 		"deposit_account",
 		"accepting_fee_account",
@@ -28,15 +29,23 @@
 		"sending_payments_tab",
 		"section_break_avdt",
 		"enable_sending",
-		"sending_config_section",
 		"sending_provider",
-		"sending_ref_id",
+		"authorizenet_sending_configuration_section",
+		"authorize_sending_endpoint",
+		"authorize_sending_api_key",
+		"authorize_sending_transaction_key",
+		"mercury_sending_configuration_section",
+		"mercury_sending_endpoint",
+		"mercury_sending_api_key",
+		"column_break_ndye",
+		"mercury_sending_account_id",
+		"wise_sending_configuration_section",
+		"wise_sending_endpoint",
+		"wise_sending_api_key",
+		"wise_sending_profile_id",
+		"column_break_nihr",
 		"fund_wise_with_direct_debit",
 		"wise_linked_bank_account_id",
-		"column_break_cssi",
-		"sending_endpoint",
-		"sending_api_key",
-		"sending_transaction_key",
 		"wise_bank_account_type",
 		"wise_bank_account_currency",
 		"sending_payments_accounts_section",
@@ -59,23 +68,6 @@
 			"unique": 1
 		},
 		{
-			"fieldname": "api_key",
-			"fieldtype": "Password",
-			"label": "API Key",
-			"mandatory_depends_on": "enable_accepting"
-		},
-		{
-			"fieldname": "transaction_key",
-			"fieldtype": "Password",
-			"label": "Transaction Key",
-			"mandatory_depends_on": "eval:doc.enable_accepting && doc.provider === \"Authorize.net\""
-		},
-		{
-			"fieldname": "ref_id",
-			"fieldtype": "Data",
-			"label": "Merchant ID"
-		},
-		{
 			"depends_on": "enable_accepting",
 			"fieldname": "section_break_5",
 			"fieldtype": "Section Break",
@@ -94,17 +86,12 @@
 			"read_only": 1
 		},
 		{
+			"depends_on": "enable_accepting",
 			"fieldname": "provider",
 			"fieldtype": "Select",
 			"label": "Provider",
 			"mandatory_depends_on": "enable_accepting",
 			"options": "\nAuthorize.net\nStripe"
-		},
-		{
-			"fieldname": "endpoint",
-			"fieldtype": "Data",
-			"label": "Endpoint",
-			"mandatory_depends_on": "eval:doc.enable_accepting && doc.provider === \"Authorize.net\""
 		},
 		{
 			"fieldname": "deposit_account",
@@ -200,55 +187,12 @@
 			"options": "Account"
 		},
 		{
-			"depends_on": "enable_accepting",
-			"fieldname": "accepting_config_section",
-			"fieldtype": "Section Break",
-			"label": "Configuration: Accepting Payments"
-		},
-		{
-			"fieldname": "column_break_zyrs",
-			"fieldtype": "Column Break"
-		},
-		{
 			"depends_on": "enable_sending",
-			"fieldname": "sending_config_section",
-			"fieldtype": "Section Break",
-			"label": "Configuration: Sending Payments"
-		},
-		{
 			"fieldname": "sending_provider",
 			"fieldtype": "Select",
 			"label": "Sending Provider",
 			"mandatory_depends_on": "enable_sending",
 			"options": "\nAuthorize.net\nMercury\nWise"
-		},
-		{
-			"description": "Required for Mercury and Wise. For Mercury, enter the Mercury Account ID for the account making transfers. For Wise, enter the Wise Profile ID for the Company making transfers. If not known, enter API credentials and click Save. The message will display the options and their IDs, if any - copy the applicable one's ID into this field.",
-			"fieldname": "sending_ref_id",
-			"fieldtype": "Data",
-			"label": "Sending Merchant ID"
-		},
-		{
-			"fieldname": "column_break_cssi",
-			"fieldtype": "Column Break"
-		},
-		{
-			"fieldname": "sending_endpoint",
-			"fieldtype": "Data",
-			"label": "Sending Endpoint",
-			"mandatory_depends_on": "eval:doc.enable_sending && (doc.provider !== doc.sending_provider) && (doc.sending_provider === \"Authorize.net\" || doc.sending_provider === \"Mercury\" || doc.sending_provider === \"Wise\")"
-		},
-		{
-			"fieldname": "sending_api_key",
-			"fieldtype": "Password",
-			"label": "Sending API Key",
-			"mandatory_depends_on": "enable_sending"
-		},
-		{
-			"fieldname": "sending_transaction_key",
-			"fieldtype": "Password",
-			"label": "Sending Transaction Key",
-			"mandatory_depends_on": "eval:doc.enable_sending && (doc.provider !== doc.sending_provider) && (doc.sending_provider === \"Authorize.net\")"
 		},
 		{
 			"fieldname": "sending_mode_of_payment",
@@ -269,7 +213,6 @@
 		},
 		{
 			"default": "0",
-			"depends_on": "eval:doc.sending_provider === \"Wise\"",
 			"description": "Automatically fund transfers with a Direct Debit bank account linked to the company profile configured in Wise. If unchecked, Electronic Payments will initiate the transfers, but the final funding step must be completed manually via the Wise website.",
 			"fieldname": "fund_wise_with_direct_debit",
 			"fieldtype": "Check",
@@ -280,7 +223,8 @@
 			"description": "The Direct Debit bank account's Account ID in Wise. If not known, enter API credentials and click Save. The message will display the account options and their IDs, if any - copy the applicable one's ID in this field.",
 			"fieldname": "wise_linked_bank_account_id",
 			"fieldtype": "Data",
-			"label": "Wise Linked Bank Account ID"
+			"label": "Wise Linked Bank Account ID",
+			"mandatory_depends_on": "fund_wise_with_direct_debit"
 		},
 		{
 			"default": "Checking",
@@ -317,10 +261,131 @@
 			"fieldtype": "Select",
 			"label": "Use Clearing Account",
 			"options": "Use Journal Entry and Clearing Account\nUse Payment Entry"
+		},
+		{
+			"fieldname": "general_tab",
+			"fieldtype": "Tab Break",
+			"label": "General"
+		},
+		{
+			"fieldname": "authorize_accepting_endpoint",
+			"fieldtype": "Data",
+			"label": "Authorize.net Endpoint",
+			"mandatory_depends_on": "eval:doc.enable_accepting && doc.provider === \"Authorize.net\""
+		},
+		{
+			"fieldname": "authorize_accepting_api_key",
+			"fieldtype": "Password",
+			"label": "Authorize.net API Key",
+			"mandatory_depends_on": "eval:doc.enable_accepting && doc.provider === \"Authorize.net\""
+		},
+		{
+			"fieldname": "authorize_accepting_transaction_key",
+			"fieldtype": "Password",
+			"label": "Authorize.net Transaction Key",
+			"mandatory_depends_on": "eval:doc.enable_accepting && doc.provider === \"Authorize.net\""
+		},
+		{
+			"depends_on": "eval:doc.enable_sending && doc.sending_provider === \"Authorize.net\"",
+			"fieldname": "authorizenet_sending_configuration_section",
+			"fieldtype": "Section Break",
+			"label": "Authorize.net Configuration"
+		},
+		{
+			"fieldname": "authorize_sending_endpoint",
+			"fieldtype": "Data",
+			"label": "Authorize.net Endpoint",
+			"mandatory_depends_on": "eval:doc.enable_sending && doc.sending_provider === \"Authorize.net\" && (doc.provider !== doc.sending_provider)"
+		},
+		{
+			"fieldname": "authorize_sending_api_key",
+			"fieldtype": "Password",
+			"label": "Authorize.net API Key",
+			"mandatory_depends_on": "eval:doc.enable_sending && doc.sending_provider === \"Authorize.net\" && (doc.provider !== doc.sending_provider)"
+		},
+		{
+			"fieldname": "authorize_sending_transaction_key",
+			"fieldtype": "Password",
+			"label": "Authorize.net Transaction Key",
+			"mandatory_depends_on": "eval:doc.enable_sending && doc.sending_provider === \"Authorize.net\" && (doc.provider !== doc.sending_provider)"
+		},
+		{
+			"fieldname": "stripe_accepting_api_key",
+			"fieldtype": "Password",
+			"label": "Stripe API Key",
+			"mandatory_depends_on": "eval:doc.enable_accepting && doc.provider === \"Stripe\""
+		},
+		{
+			"depends_on": "eval:doc.enable_accepting && doc.provider === \"Authorize.net\"",
+			"fieldname": "authorizenet_accepting_configuration_section",
+			"fieldtype": "Section Break",
+			"label": "Authorize.net Configuration"
+		},
+		{
+			"depends_on": "eval:doc.enable_accepting && doc.provider === \"Stripe\"",
+			"fieldname": "stripe_accepting_configuration_section",
+			"fieldtype": "Section Break",
+			"label": "Stripe Configuration"
+		},
+		{
+			"depends_on": "eval:doc.enable_sending && doc.sending_provider === \"Mercury\"",
+			"fieldname": "mercury_sending_configuration_section",
+			"fieldtype": "Section Break",
+			"label": "Mercury Configuration"
+		},
+		{
+			"fieldname": "mercury_sending_endpoint",
+			"fieldtype": "Data",
+			"label": "Mercury Endpoint",
+			"mandatory_depends_on": "eval:doc.enable_sending && doc.sending_provider === \"Mercury\""
+		},
+		{
+			"fieldname": "mercury_sending_api_key",
+			"fieldtype": "Password",
+			"label": "Mercury API Key",
+			"mandatory_depends_on": "eval:doc.enable_sending && doc.sending_provider === \"Mercury\""
+		},
+		{
+			"fieldname": "column_break_ndye",
+			"fieldtype": "Column Break"
+		},
+		{
+			"depends_on": "eval:doc.enable_sending && doc.sending_provider === \"Wise\"",
+			"fieldname": "wise_sending_configuration_section",
+			"fieldtype": "Section Break",
+			"label": "Wise Configuration"
+		},
+		{
+			"fieldname": "wise_sending_endpoint",
+			"fieldtype": "Data",
+			"label": "Wise Endpoint",
+			"mandatory_depends_on": "eval:doc.enable_sending && doc.sending_provider === \"Wise\""
+		},
+		{
+			"description": "Required field - enter the Mercury Account ID for the account making transfers. If not known, enter API credentials and click Save. The message will display the options and their IDs, if any - copy the applicable one's ID into this field.",
+			"fieldname": "mercury_sending_account_id",
+			"fieldtype": "Data",
+			"label": "Mercury Account ID"
+		},
+		{
+			"fieldname": "wise_sending_api_key",
+			"fieldtype": "Password",
+			"label": "Wise API Key",
+			"mandatory_depends_on": "eval:doc.enable_sending && doc.sending_provider === \"Wise\""
+		},
+		{
+			"description": "Required field - enter the Wise Profile ID for the Company making transfers. If not known, enter API credentials and click Save. The message will display the options and their IDs, if any - copy the applicable one's ID into this field.",
+			"fieldname": "wise_sending_profile_id",
+			"fieldtype": "Data",
+			"label": "Wise Profile ID"
+		},
+		{
+			"fieldname": "column_break_nihr",
+			"fieldtype": "Column Break"
 		}
 	],
 	"links": [],
-	"modified": "2025-07-01 22:02:09.369844",
+	"modified": "2025-10-07 21:06:19.638616",
 	"modified_by": "Administrator",
 	"module": "Electronic Payments",
 	"name": "Electronic Payment Settings",

--- a/electronic_payments/electronic_payments/doctype/electronic_payment_settings/electronic_payment_settings.py
+++ b/electronic_payments/electronic_payments/doctype/electronic_payment_settings/electronic_payment_settings.py
@@ -34,11 +34,11 @@ from electronic_payments.electronic_payments.doctype.electronic_payment_settings
 class ElectronicPaymentSettings(Document):
 	def validate(self):
 		self.create_electronic_payment_mop()
-		self.copy_api_config_if_same_providers()
 
 	def on_update(self):
-		self.validate_mercury_merchant_id()
-		self.validate_wise_merchant_id()
+		self.copy_api_config_if_same_providers()
+		self.validate_mercury_account_id()
+		self.validate_wise_profile_id()
 		self.validate_wise_direct_debit_account_id()
 
 	def create_electronic_payment_mop(self):
@@ -75,65 +75,77 @@ class ElectronicPaymentSettings(Document):
 	def copy_api_config_if_same_providers(self):
 		"""
 		If sending payments is enabled and accepting and sending providers match, copies API
-		configuration fields (if empty)
+		configuration fields (if empty). Currently only Authorize.net can be both accepting and
+		sending provider.
 		"""
 		if self.enable_accepting and self.enable_sending and self.provider == self.sending_provider:
-			if self.ref_id and not self.sending_ref_id:
-				self.sending_ref_id = self.sending_ref_id
-			elif self.sending_ref_id and not self.ref_id:
-				self.ref_id = self.sending_ref_id
+			ap = "authorize" if self.provider == "Authorize.net" else self.provider.lower()
+			sp = "authorize" if self.sending_provider == "Authorize.net" else self.sending_provider.lower()
+			accepting_endpoint = f"{ap}_accepting_endpoint"
+			sending_endpoint = f"{sp}_sending_endpoint"
+			accepting_api_key = f"{ap}_accepting_api_key"
+			sending_api_key = f"{sp}_sending_api_key"
 
-			if self.endpoint and not self.sending_endpoint:
-				self.sending_endpoint = self.endpoint
-			elif self.sending_endpoint and not self.endpoint:
-				self.endpoint = self.sending_endpoint
+			if ap == "authorize":
+				accepting_txn_key = f"{ap}_accepting_transaction_key"
+			if sp == "authorize":
+				sending_txn_key = f"{sp}_sending_transaction_key"
 
-			if self.api_key and not self.sending_api_key:
-				api_key = get_decrypted_password(self.doctype, self.name, "api_key", raise_exception=False)
-				self.sending_api_key = api_key
-			elif self.sending_api_key and not self.api_key:
+			if self.get(accepting_endpoint) and not self.get(sending_endpoint):
+				frappe.db.set_value(self.doctype, self.name, sending_endpoint, self.get(accepting_endpoint))
+			elif self.get(sending_endpoint) and not self.get(accepting_endpoint):
+				frappe.db.set_value(self.doctype, self.name, accepting_endpoint, self.get(sending_endpoint))
+
+			if self.get(accepting_api_key) and not self.get(sending_api_key):
 				api_key = get_decrypted_password(
-					self.doctype, self.name, "sending_api_key", raise_exception=False
+					self.doctype, self.name, accepting_api_key, raise_exception=False
 				)
-				self.api_key = api_key
+				frappe.db.set_value(self.doctype, self.name, sending_api_key, api_key)
+			elif self.get(sending_api_key) and not self.get(accepting_api_key):
+				api_key = get_decrypted_password(
+					self.doctype, self.name, sending_api_key, raise_exception=False
+				)
+				frappe.db.set_value(self.doctype, self.name, accepting_api_key, api_key)
 
-			if self.transaction_key and not self.sending_transaction_key:
+			if self.get(accepting_txn_key) and not self.get(sending_txn_key):
 				t_key = get_decrypted_password(
-					self.doctype, self.name, "transaction_key", raise_exception=False
+					self.doctype, self.name, accepting_txn_key, raise_exception=False
 				)
-				self.sending_transaction_key = t_key
-			elif self.sending_transaction_key and not self.transaction_key:
-				t_key = get_decrypted_password(
-					self.doctype, self.name, "sending_transaction_key", raise_exception=False
-				)
-				self.transaction_key = t_key
+				frappe.db.set_value(self.doctype, self.name, sending_txn_key, t_key)
+			elif self.get(sending_txn_key) and not self.get(accepting_txn_key):
+				t_key = get_decrypted_password(self.doctype, self.name, sending_txn_key, raise_exception=False)
+				frappe.db.set_value(self.doctype, self.name, accepting_txn_key, t_key)
 
-	def validate_mercury_merchant_id(self):
-		if self.enable_sending and self.sending_provider == "Mercury" and not self.sending_ref_id:
+	def validate_mercury_account_id(self):
+		if (
+			self.enable_sending
+			and self.sending_provider == "Mercury"
+			and not self.mercury_sending_account_id
+		):
 			client = Mercury()
 			accounts_resp = client.get_accounts(self.company)
 			if accounts_resp.get("message") == "Success":
 				if not accounts_resp.get("data"):
-					message = "Please fill in the Merchant ID field for Mercury with the Account ID of the account making transfers. There were no accounts found associated with the provided Mercury credentials, you can create them in the Mercury platform."
+					message = "Please fill in the Mercury Account ID field with the Account ID of the account making transfers. There were no accounts found associated with the provided Mercury credentials, you can create them in the Mercury platform."
 				else:
 					m1 = "</li><li>".join(accounts_resp["data"])
-					message = f"Please fill in the Merchant ID field for Mercury with the Account ID of the account making transfers. The following account options were found:<br><ul><li>{m1}</li></ul>"
+					message = f"Please fill in the Mercury Account ID field with the Account ID of the account making transfers. The following account options were found:<br><ul><li>{m1}</li></ul>"
 			else:
-				message = f"Please fill in the Merchant ID field for Mercury with the Account ID of the account making transfers. {accounts_resp['error']}"
+				message = f"Please fill in the Mercury Account ID field with the Account ID of the account making transfers. {accounts_resp['error']}"
 			frappe.msgprint(msg=message, title="Missing Required Field")
 
-	def validate_wise_merchant_id(self):
-		if self.enable_sending and self.sending_provider == "Wise" and not self.sending_ref_id:
+	def validate_wise_profile_id(self):
+		if self.enable_sending and self.sending_provider == "Wise" and not self.wise_sending_profile_id:
 			client = Wise()
 			profiles_resp = client.get_profiles(self.company)
 			if profiles_resp.get("message") == "Success":
 				if not profiles_resp["data"]:
-					message = "Please fill in the Merchant ID field for Wise. There were no profiles found associated with this Wise account, you can create them in the Wise platform."
+					message = "Please fill in the Wise Profile ID field. There were no profiles found associated with this Wise account, you can create them in the Wise platform."
 				else:
 					m1 = "</li><li>".join(profiles_resp["data"])
-					message = f"Please fill in the Merchant ID field for Wise. The following profiles were found for this account:<br><ul><li>{m1}</li></ul>"
+					message = f"Please fill in the Wise Profile ID field. The following profiles were found for this account:<br><ul><li>{m1}</li></ul>"
 			else:
-				message = f"Please fill in the Merchant ID field for Wise. {profiles_resp['error']}"
+				message = f"Please fill in the Wise Profile ID field. {profiles_resp['error']}"
 			frappe.msgprint(msg=message, title="Missing Required Field")
 
 	def validate_wise_direct_debit_account_id(self):
@@ -295,35 +307,37 @@ def fetch_transactions():
 		settings = frappe.get_doc("Electronic Payments Settings", settings)
 
 		# Collect and process accepting payment transactions
-		if settings.provider == "Authorize.net":
-			response = fetch_authorize_transactions(settings)
-			provider = "Authorize.net"
-		elif settings.provider == "Stripe":
-			response = fetch_stripe_transactions(settings)
-			provider = "Stripe"
+		if settings.enable_accepting:
+			if settings.provider == "Authorize.net":
+				response = fetch_authorize_transactions(settings)
+				provider = "Authorize.net"
+			elif settings.provider == "Stripe":
+				response = fetch_stripe_transactions(settings)
+				provider = "Stripe"
 
-		if response.get("message") == "Success":
-			transactions = response.get("transactions")
-			process_transactions(settings, transactions, provider)
-		else:  # TODO: handle error in way to notify users
-			errors.append(response["error"])
+			if response.get("message") == "Success":
+				transactions = response.get("transactions")
+				process_transactions(settings, transactions, provider)
+			else:  # TODO: handle error in way to notify users
+				errors.append(response["error"])
 
 		# Collect and process sending payment transactions
-		if settings.sending_provider == "Wise":
-			s_response = fetch_wise_transactions(settings)
-			s_provider = "Wise"
-		if settings.sending_provider == "Mercury":
-			s_response = fetch_mercury_transactions(settings)
-			s_provider = "Mercury"
-		elif settings.sending_provider == "Authorize.net" and not settings.provider == "Authorize.net":
-			s_response = fetch_authorize_transactions(settings)
-			s_provider = "Authorize.net"
+		if settings.enable_sending:
+			if settings.sending_provider == "Wise":
+				s_response = fetch_wise_transactions(settings)
+				s_provider = "Wise"
+			if settings.sending_provider == "Mercury":
+				s_response = fetch_mercury_transactions(settings)
+				s_provider = "Mercury"
+			elif settings.sending_provider == "Authorize.net" and not settings.provider == "Authorize.net":
+				s_response = fetch_authorize_transactions(settings)
+				s_provider = "Authorize.net"
 
-		if s_response.get("message") == "Success":
-			s_transactions = s_response.get("transactions")
-			process_transactions(settings, s_transactions, s_provider)
-		else:  # TODO: handle error in way to notify users
-			errors.append(response["error"])
+			if s_response.get("message") == "Success":
+				s_transactions = s_response.get("transactions")
+				process_transactions(settings, s_transactions, s_provider)
+			else:  # TODO: handle error in way to notify users
+				errors.append(response["error"])
 
 	if errors:
 		return ", ".join(errors)

--- a/electronic_payments/electronic_payments/doctype/electronic_payment_settings/mercury.py
+++ b/electronic_payments/electronic_payments/doctype/electronic_payment_settings/mercury.py
@@ -17,7 +17,6 @@ from electronic_payments.electronic_payments.doctype.electronic_payment_settings
 )
 from electronic_payments.electronic_payments.doctype.electronic_payment_settings.common import (
 	calculate_payment_method_fees,
-	exceeds_credit_limit,
 	get_discount_amount,
 	get_party_details,
 	get_payment_amount,
@@ -37,16 +36,17 @@ class Mercury(BaseProvider):
 		self.gateway = "Mercury"
 
 	def get_base_url_and_header(self, company):
+		"""
+		Provider-specific method for API authentication
+		"""
 		settings = frappe.get_doc("Electronic Payment Settings", {"company": company})
 		if not settings:
 			frappe.msgprint(_(f"No Electronic Payment Settings found for {company}"))
 		else:
-			api_key_field = "api_key" if settings.provider == self.provider else "sending_api_key"
-			endpoint_field = "endpoint" if settings.provider == self.provider else "sending_endpoint"
 			api_key = get_decrypted_password(
-				settings.doctype, settings.name, api_key_field, raise_exception=False
+				settings.doctype, settings.name, "mercury_sending_api_key", raise_exception=False
 			)
-			base_url = settings.get(endpoint_field)
+			base_url = settings.mercury_sending_endpoint
 			headers = {
 				"Accept": "application/json",
 				"Authorization": f"Bearer {api_key}",
@@ -54,91 +54,173 @@ class Mercury(BaseProvider):
 			}
 			return base_url, headers
 
-	def process_transaction(self, doc, data, bypass_je_pe_creation=False):
-		mop = data.mode_of_payment.replace("New ", "")
-		party = get_party_details(doc)
-		save_only = data.save_data == "Save payment data only"
-
-		if party.doctype == "Customer" or mop == "Card":
-			return {"error": _("Not Supported.")}
-
-		if (
-			mop.startswith("Saved")
-			and data.get("subject_to_credit_limit")
-			and exceeds_credit_limit(doc, data)
-		):
-			return {"error": "Credit Limit exceeded for selected Mode of Payment"}
-
-		if not mop.startswith("Saved"):
-			# new ACH, save payment data (temporarily if txn only - payment profile deleted once charge is successful)
-			pmt_profile_response = self.create_party_payment_profile(doc, data)
-			if pmt_profile_response.get("message") == "Success":
-				pp_doc = pmt_profile_response.get("payment_profile_doc")
-				data.update({"payment_profile_id": pp_doc.payment_profile_id})
-				if save_only:
-					return pmt_profile_response
-			else:  # error creating the customer payment profile
-				return pmt_profile_response
-
-		response = self.create_transfer_to_party_profile(
-			doc, data, bypass_je_pe_creation=bypass_je_pe_creation
-		)
-		return response
-
 	def create_party_profile(self, doc):
 		"""
 		Not used in Mercury
 		"""
 		return {"message": "Success", "transaction_id": None}
 
-	def process_credit_card(self, doc, data):
-		"""
-		Unsupported
-		"""
-		return {"error": _("Not supported.")}
+	def create_party_payment_profile(self, doc, data):
+		party = get_party_details(doc)
+		settings = frappe.get_doc("Electronic Payment Settings", {"company": doc.company})
+		mop = data.mode_of_payment.replace("New ", "")
+		pmt_types = [mop]
+		save_data = data.save_data in [
+			"Retain payment data for this party and process",
+			"Save payment data only",
+		]
 
-	def get_accounts(self, company):
-		"""
-		Helper function used in the Electronic Payment Settings doc to make an API call to get the
-		account IDs associated with the given access token
+		if mop not in ["ACH", "Wire"]:
+			return {"error": _("Mode of Payment not supported")}
 
-		:param company: str; the company in ERPNext the provider account is connected to. Used to
-		get the correct Electronic Payment Setting doc
-		:return: dict; either {"message": "Success", "data": list with account ID information} or
-		{"error": error message}
-		"""
 		try:
-			base_url, headers = self.get_base_url_and_header(company)
-			response = requests.get(
-				urljoin(base_url, "/api/v1/accounts"),
+			account_number = str(data.get("account_number"))
+			last4 = account_number[-4:]
+			address = {
+				"address1": data.get("address_firstline"),
+				"address2": data.get("address_secondline", ""),
+				"city": data.get("city"),
+				"region": data.get("state"),
+				"postalCode": data.get("postcode"),
+				"country": data.get("country", "US").upper(),
+			}
+			recipient_data = {
+				"name": data.get("account_holders_name"),
+				"nickname": f"{party.name}-*{last4}",
+				"emails": [data.get("email")],
+				"paymentMethod": "electronic",
+				"electronicRoutingInfo": {
+					"accountNumber": account_number,
+					"routingNumber": str(data.get("routing_number")),
+					"electronicAccountType": "businessChecking",
+					"address": address,
+				},
+			}
+			if data.get("accept_wire"):
+				recipient_data.update(
+					{
+						"domesticWireRoutingInfo": {
+							"accountNumber": account_number,
+							"routingNumber": str(data.get("routing_number")),
+							"address": address,
+						}
+					}
+				)
+				if save_data:
+					# Create a separate Wire profile
+					pmt_types = ["Wire"] + pmt_types
+
+			base_url, headers = self.get_base_url_and_header(doc.company)
+			response = requests.post(
+				urljoin(base_url, "/api/v1/recipients"),
 				headers=headers,
 				timeout=10,
+				data=json.dumps(recipient_data),
 			)
 			response.raise_for_status()
 			r = response.json()
-			if r.get("accounts"):
-				accounts_data = []
-				for account in r["accounts"]:
-					balance = account.get("availableBalance", 0)
-					a_type = account.get("kind", "unknown")
-					accounts_data.append(
-						f"Account {account['name']} of type {a_type} with available balance ${balance:,.0f} has ID: {account['id']}"
-					)
+			if r.get("id"):
+				for pmt_type in pmt_types:
+					payment_profile = frappe.new_doc("Electronic Payment Profile")
+					payment_profile.party_type = party.doctype
+					payment_profile.party = party.name
+					payment_profile.payment_type = pmt_type
+					payment_profile.payment_gateway = self.gateway
+					payment_profile.reference = f"*{last4}"
+					payment_profile.payment_profile_id = str(r.get("id"))
+					payment_profile.party_profile = None  # Not used in Mercury
+					payment_profile.retain = int(save_data)
+					payment_profile.company = doc.company
+					payment_profile.save(ignore_permissions=True)
 
-				return {"message": "Success", "data": accounts_data}
+					if payment_profile.retain and settings.create_ppm:
+						ppm = frappe.new_doc("Portal Payment Method")
+						ppm.mode_of_payment = f"{self.provider} {pmt_type}"
+						ppm.label = f"{pmt_type}-{last4}"
+						ppm.default = cint(data.get("default", 0))
+						ppm.electronic_payment_profile = payment_profile.name
+						ppm.service_charge = 0
+						ppm.parent = payment_profile.party
+						ppm.parenttype = payment_profile.party_type
+						ppm.save(ignore_permissions=True)
+
+						party_obj = frappe.get_doc(party.doctype, party.name)
+						party_obj.append("portal_payment_method", ppm)
+						party_obj.save(ignore_permissions=True)
+						data.update({"ppm_name": ppm.name})
+
+				return {"message": "Success", "payment_profile_doc": payment_profile}
 
 		except HTTPError as e_http:
 			err_msg = response.json().get("errors", {}).get("message", e_http)
 			frappe.log_error(
 				message=f"{response.json()}\n\n{e_http}\n\n{frappe.get_traceback()}",
-				title="Error requesting a list of accounts associated with this Mercury account.",
+				title=f"Error trying to create a Recipient Account for {party.name}.",
 			)
 			return {"error": f"{err_msg}"}
 
 		except requests.exceptions.RequestException as e:
 			frappe.log_error(
 				message=f"{e}\n\n{frappe.get_traceback()}",
-				title="Request error getting a list of accounts associated with this Mercury account.",
+				title=f"Request error while trying to create a Recipient Account for {party.name}.",
+			)
+			return {"error": f"{e}"}
+
+	def get_party_payment_profile(self, company, electronic_payment_profile_name):
+		party, payment_profile_id = frappe.get_value(
+			"Electronic Payment Profile",
+			{"name": electronic_payment_profile_name},
+			["party", "payment_profile_id"],
+		)
+		try:
+			base_url, headers = self.get_base_url_and_header(company)
+			response = requests.get(
+				urljoin(base_url, f"/api/v1/recipient/{payment_profile_id}"),
+				headers=headers,
+				timeout=10,
+			)
+			response.raise_for_status()
+			r = response.json()
+			if r.get("id"):
+				state = r.get("electronicRoutingInfo", {}).get("address", {}).get("region", "")
+				state_label = state_label_lookup(state)
+				return {
+					"message": "Success",
+					"data": {
+						"first_name": r.get("name"),
+						"last_name": "",
+						"email": r.get("emails", [""])[0],
+						"account_type": r.get("electronicRoutingInfo", {}).get("electronicAccountType", ""),
+						"routing_number": str(r.get("electronicRoutingInfo", {}).get("routingNumber", "")),
+						"account_number": str(r.get("electronicRoutingInfo", {}).get("accountNumber", "")),
+						"name_on_account": r.get("name", ""),
+						"address_firstline": r.get("electronicRoutingInfo", {})
+						.get("address", {})
+						.get("address1", ""),
+						"address_secondline": r.get("electronicRoutingInfo", {})
+						.get("address", {})
+						.get("address2", ""),
+						"city": r.get("electronicRoutingInfo", {}).get("address", {}).get("city", ""),
+						"state": state,
+						"state_label": state_label,
+						"postcode": r.get("electronicRoutingInfo", {}).get("address", {}).get("postalCode", ""),
+						"country": r.get("electronicRoutingInfo", {}).get("address", {}).get("country", ""),
+						"echeck_type": None,
+					},
+				}
+
+		except HTTPError as e_http:
+			err_msg = response.json().get("errors", {}).get("message", e_http)
+			frappe.log_error(
+				message=f"{response.json()}\n\n{e_http}\n\n{frappe.get_traceback()}",
+				title=f"Error collecting payment profile for {party}",
+			)
+			return {"error": f"{err_msg}"}
+
+		except requests.exceptions.RequestException as e:
+			frappe.log_error(
+				message=f"{e}\n\n{frappe.get_traceback()}",
+				title=f"Request error collecting payment profile for {party}",
 			)
 			return {"error": f"{e}"}
 
@@ -260,169 +342,34 @@ class Mercury(BaseProvider):
 			)
 			return {"error": f"{e}"}
 
-	def get_party_payment_profile(self, company, electronic_payment_profile_name):
-		party, payment_profile_id = frappe.get_value(
-			"Electronic Payment Profile",
-			{"name": electronic_payment_profile_name},
-			["party", "payment_profile_id"],
+	def delete_payment_profile(self, company, payment_profile_id):
+		# Delete from ERPNext
+		# In event a Wire EPP were also created (which would have the same ID), collect all
+		epps = frappe.get_all("Electronic Payment Profile", {"payment_profile_id": payment_profile_id})
+		for ep in epps:
+			epp_name, party, reference = frappe.get_value(
+				"Electronic Payment Profile",
+				ep,
+				["name", "party", "reference"],
+			)
+			pmm_name = frappe.get_value("Portal Payment Method", {"electronic_payment_profile": epp_name})
+
+			frappe.delete_doc("Portal Payment Method", pmm_name, ignore_permissions=True)
+			frappe.delete_doc("Electronic Payment Profile", epp_name, ignore_permissions=True)
+
+		# Deleting Recipients not available via API, log error that it must be done manually
+		frappe.log_error(
+			message=f"Mercury does not allow deleting Recipients via the API. Please visit mercury.com to manually remove the payment profile {reference} for {party}.",
+			title=f"Payment profile for {party} must be deleted manually at Mercury.com",
 		)
-		try:
-			base_url, headers = self.get_base_url_and_header(company)
-			response = requests.get(
-				urljoin(base_url, f"/api/v1/recipient/{payment_profile_id}"),
-				headers=headers,
-				timeout=10,
-			)
-			response.raise_for_status()
-			r = response.json()
-			if r.get("id"):
-				state = r.get("electronicRoutingInfo", {}).get("address", {}).get("region", "")
-				state_label = state_label_lookup(state)
-				return {
-					"message": "Success",
-					"data": {
-						"first_name": r.get("name"),
-						"last_name": "",
-						"email": r.get("emails", [""])[0],
-						"account_type": r.get("electronicRoutingInfo", {}).get("electronicAccountType", ""),
-						"routing_number": str(r.get("electronicRoutingInfo", {}).get("routingNumber", "")),
-						"account_number": str(r.get("electronicRoutingInfo", {}).get("accountNumber", "")),
-						"name_on_account": r.get("name", ""),
-						"address_firstline": r.get("electronicRoutingInfo", {})
-						.get("address", {})
-						.get("address1", ""),
-						"address_secondline": r.get("electronicRoutingInfo", {})
-						.get("address", {})
-						.get("address2", ""),
-						"city": r.get("electronicRoutingInfo", {}).get("address", {}).get("city", ""),
-						"state": state,
-						"state_label": state_label,
-						"postcode": r.get("electronicRoutingInfo", {}).get("address", {}).get("postalCode", ""),
-						"country": r.get("electronicRoutingInfo", {}).get("address", {}).get("country", ""),
-						"echeck_type": None,
-					},
-				}
+		return {"message": "Success"}
 
-		except HTTPError as e_http:
-			err_msg = response.json().get("errors", {}).get("message", e_http)
-			frappe.log_error(
-				message=f"{response.json()}\n\n{e_http}\n\n{frappe.get_traceback()}",
-				title=f"Error collecting payment profile for {party}",
-			)
-			return {"error": f"{err_msg}"}
+	def delete_party_profile(self, company, party, party_profile_id):
+		# Not used in Mercury
+		return {"message": "Success"}
 
-		except requests.exceptions.RequestException as e:
-			frappe.log_error(
-				message=f"{e}\n\n{frappe.get_traceback()}",
-				title=f"Request error collecting payment profile for {party}",
-			)
-			return {"error": f"{e}"}
-
-	def create_party_payment_profile(self, doc, data):
-		party = get_party_details(doc)
-		settings = frappe.get_doc("Electronic Payment Settings", {"company": doc.company})
-		mop = data.mode_of_payment.replace("New ", "")
-		pmt_types = [mop]
-		save_data = data.save_data in [
-			"Retain payment data for this party and process",
-			"Save payment data only",
-		]
-
-		if mop not in ["ACH", "Wire"]:
-			return {"error": _("Mode of Payment not supported")}
-
-		try:
-			account_number = str(data.get("account_number"))
-			last4 = account_number[-4:]
-			address = {
-				"address1": data.get("address_firstline"),
-				"address2": data.get("address_secondline", ""),
-				"city": data.get("city"),
-				"region": data.get("state"),
-				"postalCode": data.get("postcode"),
-				"country": data.get("country", "US").upper(),
-			}
-			recipient_data = {
-				"name": data.get("account_holders_name"),
-				"nickname": f"{party.name}-*{last4}",
-				"emails": [data.get("email")],
-				"paymentMethod": "electronic",
-				"electronicRoutingInfo": {
-					"accountNumber": account_number,
-					"routingNumber": str(data.get("routing_number")),
-					"electronicAccountType": "businessChecking",
-					"address": address,
-				},
-			}
-			if data.get("accept_wire"):
-				recipient_data.update(
-					{
-						"domesticWireRoutingInfo": {
-							"accountNumber": account_number,
-							"routingNumber": str(data.get("routing_number")),
-							"address": address,
-						}
-					}
-				)
-				if save_data:
-					# Create a separate Wire profile
-					pmt_types = ["Wire"] + pmt_types
-
-			base_url, headers = self.get_base_url_and_header(doc.company)
-			response = requests.post(
-				urljoin(base_url, "/api/v1/recipients"),
-				headers=headers,
-				timeout=10,
-				data=json.dumps(recipient_data),
-			)
-			response.raise_for_status()
-			r = response.json()
-			if r.get("id"):
-				for pmt_type in pmt_types:
-					payment_profile = frappe.new_doc("Electronic Payment Profile")
-					payment_profile.party_type = party.doctype
-					payment_profile.party = party.name
-					payment_profile.payment_type = pmt_type
-					payment_profile.payment_gateway = self.gateway
-					payment_profile.reference = f"*{last4}"
-					payment_profile.payment_profile_id = str(r.get("id"))
-					payment_profile.party_profile = None  # Not used in Mercury
-					payment_profile.retain = int(save_data)
-					payment_profile.company = doc.company
-					payment_profile.save(ignore_permissions=True)
-
-					if payment_profile.retain and settings.create_ppm:
-						ppm = frappe.new_doc("Portal Payment Method")
-						ppm.mode_of_payment = f"{self.provider} {pmt_type}"
-						ppm.label = f"{pmt_type}-{last4}"
-						ppm.default = cint(data.get("default", 0))
-						ppm.electronic_payment_profile = payment_profile.name
-						ppm.service_charge = 0
-						ppm.parent = payment_profile.party
-						ppm.parenttype = payment_profile.party_type
-						ppm.save(ignore_permissions=True)
-
-						party_obj = frappe.get_doc(party.doctype, party.name)
-						party_obj.append("portal_payment_method", ppm)
-						party_obj.save(ignore_permissions=True)
-						data.update({"ppm_name": ppm.name})
-
-				return {"message": "Success", "payment_profile_doc": payment_profile}
-
-		except HTTPError as e_http:
-			err_msg = response.json().get("errors", {}).get("message", e_http)
-			frappe.log_error(
-				message=f"{response.json()}\n\n{e_http}\n\n{frappe.get_traceback()}",
-				title=f"Error trying to create a Recipient Account for {party.name}.",
-			)
-			return {"error": f"{err_msg}"}
-
-		except requests.exceptions.RequestException as e:
-			frappe.log_error(
-				message=f"{e}\n\n{frappe.get_traceback()}",
-				title=f"Request error while trying to create a Recipient Account for {party.name}.",
-			)
-			return {"error": f"{e}"}
+	def process_credit_card(self, doc, data):
+		return {"error": _("Not supported.")}
 
 	def charge_party_profile(self, doc, data):
 		return {"error": _("Not supported")}
@@ -450,8 +397,7 @@ class Mercury(BaseProvider):
 		"""
 		party = get_party_details(doc)
 		settings = frappe.get_doc("Electronic Payment Settings", {"company": doc.company})
-		merch_id_field = "ref_id" if settings.provider == self.provider else "sending_ref_id"
-		account_id = settings.get(merch_id_field)
+		account_id = settings.mercury_sending_account_id
 		payment_profile_id = data.get("payment_profile_id")
 		payment_amount = data.get("amount") or get_payment_amount(doc, data)
 		discount_amount = 0 if data.get("amount") else get_discount_amount(doc, data)
@@ -526,38 +472,35 @@ class Mercury(BaseProvider):
 			return {"error": f"{e}"}
 
 	def refund_transaction(self, doc, data):
-		"""
-		TODO: how to request refund?
-		"""
-		orig_transaction_id = doc.electronic_payment_reference
-		amount = data.get("amount")
+		# orig_transaction_id = doc.electronic_payment_reference
+		# amount = data.get("amount")
 
-		# Validate amount is <= doc grand total less any other refunds
-		prev_refunded_amt = 0
-		if amount > (doc.grand_total - prev_refunded_amt):
-			frappe.throw(
-				_(
-					"The refund amount must be less than or equal to the grand total less any previously refunded amounts."
-				)
-			)
+		# # Validate amount is <= doc grand total less any other refunds
+		# prev_refunded_amt = 0
+		# if amount > (doc.grand_total - prev_refunded_amt):
+		# 	frappe.throw(
+		# 		_(
+		# 			"The refund amount must be less than or equal to the grand total less any previously refunded amounts."
+		# 		)
+		# 	)
 
-		# Request transaction details for payment information
-		txn_details_response = self.get_transaction_details(doc.company, orig_transaction_id)
-		error_message = ""
+		# # Request transaction details for payment information
+		# txn_details_response = self.get_transaction_details(doc.company, orig_transaction_id)
+		# error_message = ""
 
-		if txn_details_response.get("message") == "Success":
-			payment_details = txn_details_response.get("payment_details")
-		else:
-			return txn_details_response
-		# TODO refund in API and ERPNext
+		# if txn_details_response.get("message") == "Success":
+		# 	payment_details = txn_details_response.get("payment_details")
+		# else:
+		# 	return txn_details_response
+		# # TODO refund in API and ERPNext
+		raise NotImplementedError
 
 	def void_transaction(self, doc, data):
 		return {"error": _("Not supported.")}
 
 	def get_transaction_details(self, company, transaction_id):
 		settings = frappe.get_doc("Electronic Payment Settings", {"company": company})
-		merch_id_field = "ref_id" if settings.provider == self.provider else "sending_ref_id"
-		account_id = settings.get(merch_id_field)
+		account_id = settings.mercury_sending_account_id
 		try:
 			base_url, headers = self.get_base_url_and_header(company)
 			response = requests.get(
@@ -600,34 +543,54 @@ class Mercury(BaseProvider):
 			)
 			return {"error": f"{e}"}
 
-	def delete_payment_profile(self, company, payment_profile_id):
-		# Delete from ERPNext
-		# In event a Wire EPP were also created (which would have the same ID), collect all
-		epps = frappe.get_all("Electronic Payment Profile", {"payment_profile_id": payment_profile_id})
-		for ep in epps:
-			epp_name, party, reference = frappe.get_value(
-				"Electronic Payment Profile",
-				ep,
-				["name", "party", "reference"],
+	def get_accounts(self, company):
+		"""
+		Provider-specific method used in the Electronic Payment Settings doc to get the account
+		IDs associated with the given access token
+
+		:param company: str; the company in ERPNext the provider account is connected to. Used to
+		get the correct Electronic Payment Setting doc
+		:return: dict; either {"message": "Success", "data": list with account ID information} or
+		{"error": error_message}
+		"""
+		try:
+			base_url, headers = self.get_base_url_and_header(company)
+			response = requests.get(
+				urljoin(base_url, "/api/v1/accounts"),
+				headers=headers,
+				timeout=10,
 			)
-			pmm_name = frappe.get_value("Portal Payment Method", {"electronic_payment_profile": epp_name})
+			response.raise_for_status()
+			r = response.json()
+			if r.get("accounts"):
+				accounts_data = []
+				for account in r["accounts"]:
+					balance = account.get("availableBalance", 0)
+					a_type = account.get("kind", "unknown")
+					accounts_data.append(
+						f"Account {account['name']} of type {a_type} with available balance ${balance:,.0f} has ID: {account['id']}"
+					)
 
-			frappe.delete_doc("Portal Payment Method", pmm_name, ignore_permissions=True)
-			frappe.delete_doc("Electronic Payment Profile", epp_name, ignore_permissions=True)
+				return {"message": "Success", "data": accounts_data}
 
-		# Deleting Recipients not available via API, log error that it must be done manually
-		frappe.log_error(
-			message=f"Mercury does not allow deleting Recipients via the API. Please visit mercury.com to manually remove the payment profile {reference} for {party}.",
-			title=f"Payment profile for {party} must be deleted manually at Mercury.com",
-		)
-		return {"message": "Success"}
+		except HTTPError as e_http:
+			err_msg = response.json().get("errors", {}).get("message", e_http)
+			frappe.log_error(
+				message=f"{response.json()}\n\n{e_http}\n\n{frappe.get_traceback()}",
+				title="Error requesting a list of accounts associated with this Mercury account.",
+			)
+			return {"error": f"{err_msg}"}
 
-	def delete_party_profile(self, company, party, party_profile_id):
-		# Not used in Mercury
-		return {"message": "Success"}
+		except requests.exceptions.RequestException as e:
+			frappe.log_error(
+				message=f"{e}\n\n{frappe.get_traceback()}",
+				title="Request error getting a list of accounts associated with this Mercury account.",
+			)
+			return {"error": f"{e}"}
 
 
 def fetch_mercury_transactions(settings):
 	# TODO
 	settings = frappe._dict(json.loads(settings)) if isinstance(settings, str) else settings
+
 	return []

--- a/electronic_payments/electronic_payments/doctype/electronic_payment_settings/mercury.py
+++ b/electronic_payments/electronic_payments/doctype/electronic_payment_settings/mercury.py
@@ -12,6 +12,9 @@ from frappe.utils import cint, flt
 from frappe.utils.password import get_decrypted_password
 from requests.exceptions import HTTPError
 
+from electronic_payments.electronic_payments.doctype.electronic_payment_settings.base import (
+	BaseProvider,
+)
 from electronic_payments.electronic_payments.doctype.electronic_payment_settings.common import (
 	calculate_payment_method_fees,
 	exceeds_credit_limit,
@@ -24,14 +27,22 @@ from electronic_payments.electronic_payments.doctype.electronic_payment_settings
 )
 
 
-class Mercury:
+class Mercury(BaseProvider):
+	def __init__(self):
+		"""
+		self.provider value should match the selection text in Electronic Payment Settings
+		self.gateway value should match the selection text in Electronic Payment Profile
+		"""
+		self.provider = "Mercury"
+		self.gateway = "Mercury"
+
 	def get_base_url_and_header(self, company):
 		settings = frappe.get_doc("Electronic Payment Settings", {"company": company})
 		if not settings:
 			frappe.msgprint(_(f"No Electronic Payment Settings found for {company}"))
 		else:
-			api_key_field = "api_key" if settings.provider == "Mercury" else "sending_api_key"
-			endpoint_field = "endpoint" if settings.provider == "Mercury" else "sending_endpoint"
+			api_key_field = "api_key" if settings.provider == self.provider else "sending_api_key"
+			endpoint_field = "endpoint" if settings.provider == self.provider else "sending_endpoint"
 			api_key = get_decrypted_password(
 				settings.doctype, settings.name, api_key_field, raise_exception=False
 			)
@@ -74,6 +85,12 @@ class Mercury:
 		)
 		return response
 
+	def create_party_profile(self, doc):
+		"""
+		Not used in Mercury
+		"""
+		return {"message": "Success", "transaction_id": None}
+
 	def process_credit_card(self, doc, data):
 		"""
 		Unsupported
@@ -81,6 +98,15 @@ class Mercury:
 		return {"error": _("Not supported.")}
 
 	def get_accounts(self, company):
+		"""
+		Helper function used in the Electronic Payment Settings doc to make an API call to get the
+		account IDs associated with the given access token
+
+		:param company: str; the company in ERPNext the provider account is connected to. Used to
+		get the correct Electronic Payment Setting doc
+		:return: dict; either {"message": "Success", "data": list with account ID information} or
+		{"error": error message}
+		"""
 		try:
 			base_url, headers = self.get_base_url_and_header(company)
 			response = requests.get(
@@ -116,7 +142,7 @@ class Mercury:
 			)
 			return {"error": f"{e}"}
 
-	def edit_customer_payment_profile(self, company, electronic_payment_profile_name, data):
+	def edit_payment_profile(self, company, electronic_payment_profile_name, data):
 		payment_profile = frappe.get_doc(
 			"Electronic Payment Profile", {"name": electronic_payment_profile_name}
 		)
@@ -204,7 +230,7 @@ class Mercury:
 					payment_profile.save(ignore_permissions=True)
 
 					ppm = frappe.new_doc("Portal Payment Method")
-					ppm.mode_of_payment = "Mercury Wire"
+					ppm.mode_of_payment = f"{self.provider} Wire"
 					ppm.label = f"Wire-{last4}"
 					ppm.default = 0
 					ppm.electronic_payment_profile = payment_profile.name
@@ -357,7 +383,7 @@ class Mercury:
 					payment_profile.party_type = party.doctype
 					payment_profile.party = party.name
 					payment_profile.payment_type = pmt_type
-					payment_profile.payment_gateway = "Mercury"
+					payment_profile.payment_gateway = self.gateway
 					payment_profile.reference = f"*{last4}"
 					payment_profile.payment_profile_id = str(r.get("id"))
 					payment_profile.party_profile = None  # Not used in Mercury
@@ -367,7 +393,7 @@ class Mercury:
 
 					if payment_profile.retain and settings.create_ppm:
 						ppm = frappe.new_doc("Portal Payment Method")
-						ppm.mode_of_payment = f"Mercury {pmt_type}"
+						ppm.mode_of_payment = f"{self.provider} {pmt_type}"
 						ppm.label = f"{pmt_type}-{last4}"
 						ppm.default = cint(data.get("default", 0))
 						ppm.electronic_payment_profile = payment_profile.name
@@ -424,7 +450,7 @@ class Mercury:
 		"""
 		party = get_party_details(doc)
 		settings = frappe.get_doc("Electronic Payment Settings", {"company": doc.company})
-		merch_id_field = "ref_id" if settings.provider == "Mercury" else "sending_ref_id"
+		merch_id_field = "ref_id" if settings.provider == self.provider else "sending_ref_id"
 		account_id = settings.get(merch_id_field)
 		payment_profile_id = data.get("payment_profile_id")
 		payment_amount = data.get("amount") or get_payment_amount(doc, data)
@@ -530,7 +556,7 @@ class Mercury:
 
 	def get_transaction_details(self, company, transaction_id):
 		settings = frappe.get_doc("Electronic Payment Settings", {"company": company})
-		merch_id_field = "ref_id" if settings.provider == "Mercury" else "sending_ref_id"
+		merch_id_field = "ref_id" if settings.provider == self.provider else "sending_ref_id"
 		account_id = settings.get(merch_id_field)
 		try:
 			base_url, headers = self.get_base_url_and_header(company)

--- a/electronic_payments/electronic_payments/doctype/electronic_payment_settings/stripe.py
+++ b/electronic_payments/electronic_payments/doctype/electronic_payment_settings/stripe.py
@@ -17,7 +17,6 @@ from electronic_payments.electronic_payments.doctype.electronic_payment_settings
 )
 from electronic_payments.electronic_payments.doctype.electronic_payment_settings.common import (
 	calculate_payment_method_fees,
-	exceeds_credit_limit,
 	get_discount_amount,
 	get_party_details,
 	get_party_profile_id,
@@ -72,52 +71,16 @@ class Stripe(BaseProvider):
 		self.gateway = "Stripe"
 
 	def get_password(self, company):
+		"""
+		Provider-specific method for API authentication
+		"""
 		settings = frappe.get_doc("Electronic Payment Settings", {"company": company})
 		if not settings:
 			frappe.msgprint(_(f"No Electronic Payment Settings found for {company}"))
 		else:
-			api_key_field = "api_key" if settings.provider == self.provider else "sending_api_key"
 			stripe.api_key = get_decrypted_password(
-				settings.doctype, settings.name, api_key_field, raise_exception=False
+				settings.doctype, settings.name, "stripe_accepting_api_key", raise_exception=False
 			)
-
-	def process_transaction(self, doc, data):
-		mop = data.mode_of_payment.replace("New ", "")
-		party = get_party_details(doc)
-		save_only = data.save_data == "Save payment data only"
-
-		if mop.startswith("Saved"):
-			if data.get("subject_to_credit_limit") and exceeds_credit_limit(doc, data):
-				return {"error": "Credit Limit exceeded for selected Mode of Payment"}
-			if party.doctype == "Customer":
-				response = self.charge_party_profile(doc, data)
-			else:
-				response = {"error": _("Not Supported.")}
-		elif mop == "ACH":
-			# TODO: update UI to handle response, handle save_data option
-			response = self.create_payment_intent(doc, data)
-		else:  # New Card
-			if data.get("save_data") == "Charge now":
-				response = self.process_credit_card(doc, data)
-			else:  # saves payment data (will delete payment profile doc after charging if for txn only)
-				party_response = self.create_party_profile(doc)
-				if party_response.get("message") == "Success":
-					data.update({"party_profile_id": party_response.get("transaction_id")})
-					pmt_profile_response = self.create_party_payment_profile(doc, data)
-					if pmt_profile_response.get("message") == "Success":
-						pp_doc = pmt_profile_response.get("payment_profile_doc")
-						data.update({"payment_profile_id": pp_doc.payment_profile_id})
-						if save_only:
-							return pmt_profile_response
-						if party.doctype == "Customer":
-							response = self.charge_party_profile(doc, data)
-						else:
-							response = {"error": _("Not Supported.")}
-					else:  # error creating the customer payment profile
-						return pmt_profile_response
-				else:  # error creating customer profile
-					return party_response
-		return response
 
 	def currency_multiplier(self, currency):
 		zero_decimal = (
@@ -227,92 +190,6 @@ class Stripe(BaseProvider):
 			try:
 				frappe.log_error(message=frappe.get_traceback(), title=f"{e.code}: {e.type}. {e.message}")
 				return {"error": f"{e.code}: {e.type}. {e.message}"}
-			except Exception as _e:  # non-Stripe error, something else went wrong
-				frappe.log_error(message=frappe.get_traceback(), title=f"{e}")
-				return {"error": f"{e}"}
-
-	def create_payment_method(self, doc, data):
-		self.get_password(doc.company)
-		try:
-			if data.mode_of_payment.replace("New ", "") == "Card":
-				card_number = data.get("card_number")
-				card_number = card_number.replace(" ", "")
-				# TODO: replace with UI data collection
-				response = stripe.PaymentMethod.create(
-					type="card",
-					card={
-						"number": card_number,
-						"exp_month": int(data.get("card_expiration_date").split("-")[1]),
-						"exp_year": int(data.get("card_expiration_date").split("-")[0]),
-						"cvc": data.get("card_cvc"),
-					},
-				)
-			elif (
-				data.mode_of_payment.replace("New ", "") == "ACH"
-			):  # TODO: replace with UI data collection / mandate / verification process
-				response = stripe.PaymentMethod.create(
-					type="us_bank_account",
-					us_bank_account={
-						"account_holder_type": frappe.get_value(
-							"Customer", doc.customer, "customer_type"
-						).lower(),  # 'individual' or 'company'
-						"routing_number": str(data.get("routing_number")),
-						"account_number": str(data.get("account_number")),
-					},
-					billing_details={"name": data.get("account_holders_name"), "email": ""},
-				)
-			else:
-				return {"error": "Unsupported payment method provided."}
-
-			return {"message": "Success", "transaction_id": response.id}
-		except Exception as e:
-			try:
-				frappe.log_error(message=frappe.get_traceback(), title=f"{e.code}: {e.type}. {e.message}")
-				return {
-					"error": f"{e.code}: {e.type}. {e.message}"
-				}  # e.code has status code, e.type is one of 4 error types, e.message is a human-readable message providing more details about the error
-			except Exception as _e:  # non-Stripe error, something else went wrong
-				frappe.log_error(message=frappe.get_traceback(), title=f"{e}")
-				return {"error": f"{e}"}
-
-	def create_payment_intent(self, doc, data):
-		# For New ACH transactions, creates an un-confirmed PaymentIntent and returns the client secret
-		self.get_password(doc.company)
-		try:
-			total_to_charge = flt(
-				doc.grand_total + (data.get("additional_charges") or 0),
-				frappe.get_precision(doc.doctype, "grand_total"),
-			)
-			customer_response = self.create_party_profile(doc)
-			if customer_response.get("message") == "Success":
-				currency = frappe.defaults.get_global_default("currency").lower()
-				response = stripe.PaymentIntent.create(
-					amount=int(total_to_charge * self.currency_multiplier(currency)),
-					currency=currency,
-					customer=customer_response.get("transaction_id"),
-					description=doc.name,
-					setup_future_usage="off_session",  # Indicates this payment method will be used in future PaymentIntents and saves to Customer. off_session = can charge customer at later time, on_session = can only charge in live session
-					payment_method_types=["us_bank_account", "card"],
-					# payment_method_options={
-					# 	"us_bank_account": {
-					# 	"financial_connections": {"permissions": ["payment_method", "balances"]},
-					# 	},
-					# },
-				)
-				return {
-					"message": "Success",
-					"transaction_id": response.id,
-					"customer_profile_id": response.customer,
-					"client_secret": response.client_secret,
-				}
-			else:  # error creating customer profile
-				return customer_response
-		except Exception as e:
-			try:
-				frappe.log_error(message=frappe.get_traceback(), title=f"{e.code}: {e.type}. {e.message}")
-				return {
-					"error": f"{e.code}: {e.type}. {e.message}"
-				}  # e.code has status code, e.type is one of 4 error types, e.message is a human-readable message providing more details about the error
 			except Exception as _e:  # non-Stripe error, something else went wrong
 				frappe.log_error(message=frappe.get_traceback(), title=f"{e}")
 				return {"error": f"{e}"}
@@ -460,6 +337,64 @@ class Stripe(BaseProvider):
 				frappe.log_error(message=frappe.get_traceback(), title=f"{e}")
 				return {"error": f"{e}"}
 
+	def process_credit_card(self, doc, data):
+		self.get_password(doc.company)
+		try:
+			pm_response = self.create_payment_method(doc, data)
+			if pm_response.get("message") == "Success":
+				currency = frappe.defaults.get_global_default("currency").lower()
+				card_number = data.get("card_number")
+				card_number = card_number.replace(" ", "")
+				payment_amount = data.get("amount") or get_payment_amount(doc, data)
+				discount_amount = 0 if data.get("amount") else get_discount_amount(doc, data)
+				if data.get("ppm_name") and not data.get("additional_charges"):
+					data.update({"additional_charges": calculate_payment_method_fees(doc, data)})
+				total_to_charge = flt(
+					payment_amount - discount_amount + data.get("additional_charges", 0),
+					frappe.get_precision(doc.doctype, "grand_total"),
+				)
+				response = stripe.PaymentIntent.create(
+					amount=int(total_to_charge * self.currency_multiplier(currency)),
+					currency=currency,
+					confirm=True,
+					description=doc.name,
+					payment_method=pm_response.get("transaction_id"),
+					# automatic_payment_methods={"enabled": True},  # Company would need to set up payment methods in their Stripe dashboard
+					# off_session=False if data.get('save_date') != 'Charge now' else True,  # Use with confirm=True and collecting payment data to charge later
+					# customer=None,  # Stripe customer ID. If provided and setup_future_usage is present, will save payment method to that customer for future use
+					# setup_future_usage='off_session',  # Indicates this payment method will be used in future PaymentIntents. Saves to Customer if present (if not, can be attached to a customer after transaction completes). off_session = can charge customer at later time, on_session = can only charge in live session
+				)
+
+				if response.status == "succeeded":
+					frappe.db.set_value(doc.doctype, doc.name, "electronic_payment_reference", str(response.id))
+					queue_method_as_admin(
+						process_electronic_payment, doc=doc, data=data, transaction_id=str(response.id)
+					)
+					return {"message": "Success", "transaction_id": response.id}
+				elif response.status == "processing":
+					# TODO: handle follow up in UI
+					return {"error": "Transaction processing"}
+				elif response.status in [
+					"requires_action",
+					"requires_confirmation",
+					"requires_capture",
+				]:
+					# TODO: requires_action needs customer authentication (handle on client-side), parameter values should bypass other statuses
+					return {"error": f'Further action required: {response.status.split("_")[-1]}'}
+				else:  # 'requires_payment_method' aka the payment attempt failed
+					return {"error": "Payment failed"}
+			else:  # error creating the payment method
+				return pm_response
+		except Exception as e:
+			try:
+				frappe.log_error(message=frappe.get_traceback(), title=f"{e.code}: {e.type}. {e.message}")
+				return {
+					"error": f"{e.code}: {e.type}. {e.message}"
+				}  # e.code has status code, e.type is one of 4 error types, e.message is a human-readable message providing more details about the error
+			except Exception as _e:  # non-Stripe error, something else went wrong
+				frappe.log_error(message=frappe.get_traceback(), title=f"{e}")
+				return {"error": f"{e}"}
+
 	def charge_party_profile(self, doc, data):
 		self.get_password(doc.company)
 		party = get_party_details(doc)
@@ -528,69 +463,11 @@ class Stripe(BaseProvider):
 	def create_transfer_to_party_profile(self, doc, data, bypass_je_pe_creation=False):
 		return {"error": _("Not supported.")}
 
-	def process_credit_card(self, doc, data):
-		self.get_password(doc.company)
-		try:
-			pm_response = self.create_payment_method(doc, data)
-			if pm_response.get("message") == "Success":
-				currency = frappe.defaults.get_global_default("currency").lower()
-				card_number = data.get("card_number")
-				card_number = card_number.replace(" ", "")
-				payment_amount = data.get("amount") or get_payment_amount(doc, data)
-				discount_amount = 0 if data.get("amount") else get_discount_amount(doc, data)
-				if data.get("ppm_name") and not data.get("additional_charges"):
-					data.update({"additional_charges": calculate_payment_method_fees(doc, data)})
-				total_to_charge = flt(
-					payment_amount - discount_amount + data.get("additional_charges", 0),
-					frappe.get_precision(doc.doctype, "grand_total"),
-				)
-				response = stripe.PaymentIntent.create(
-					amount=int(total_to_charge * self.currency_multiplier(currency)),
-					currency=currency,
-					confirm=True,
-					description=doc.name,
-					payment_method=pm_response.get("transaction_id"),
-					# automatic_payment_methods={"enabled": True},  # Company would need to set up payment methods in their Stripe dashboard
-					# off_session=False if data.get('save_date') != 'Charge now' else True,  # Use with confirm=True and collecting payment data to charge later
-					# customer=None,  # Stripe customer ID. If provided and setup_future_usage is present, will save payment method to that customer for future use
-					# setup_future_usage='off_session',  # Indicates this payment method will be used in future PaymentIntents. Saves to Customer if present (if not, can be attached to a customer after transaction completes). off_session = can charge customer at later time, on_session = can only charge in live session
-				)
-
-				if response.status == "succeeded":
-					frappe.db.set_value(doc.doctype, doc.name, "electronic_payment_reference", str(response.id))
-					queue_method_as_admin(
-						process_electronic_payment, doc=doc, data=data, transaction_id=str(response.id)
-					)
-					return {"message": "Success", "transaction_id": response.id}
-				elif response.status == "processing":
-					# TODO: handle follow up in UI
-					return {"error": "Transaction processing"}
-				elif response.status in [
-					"requires_action",
-					"requires_confirmation",
-					"requires_capture",
-				]:
-					# TODO: requires_action needs customer authentication (handle on client-side), parameter values should bypass other statuses
-					return {"error": f'Further action required: {response.status.split("_")[-1]}'}
-				else:  # 'requires_payment_method' aka the payment attempt failed
-					return {"error": "Payment failed"}
-			else:  # error creating the payment method
-				return pm_response
-		except Exception as e:
-			try:
-				frappe.log_error(message=frappe.get_traceback(), title=f"{e.code}: {e.type}. {e.message}")
-				return {
-					"error": f"{e.code}: {e.type}. {e.message}"
-				}  # e.code has status code, e.type is one of 4 error types, e.message is a human-readable message providing more details about the error
-			except Exception as _e:  # non-Stripe error, something else went wrong
-				frappe.log_error(message=frappe.get_traceback(), title=f"{e}")
-				return {"error": f"{e}"}
-
 	def refund_transaction(self, doc, data):
 		"""
 		TODO: clarify where this function is called and what data can be passed
-		Function needs: transaction ID of original charge and amount to refund
-		        (amount technically only needed if partial refund, will default to entire charge)
+		Function needs: transaction ID of original charge and amount to refund (amount technically
+		only needed if partial refund, will default to entire charge)
 		"""
 		self.get_password(doc.company)
 		orig_transaction_id = doc.electronic_payment_reference
@@ -623,6 +500,92 @@ class Stripe(BaseProvider):
 
 	def get_transaction_details(self, company, transaction_id):
 		return {"error": _("Not supported.")}
+
+	def create_payment_method(self, doc, data):
+		self.get_password(doc.company)
+		try:
+			if data.mode_of_payment.replace("New ", "") == "Card":
+				card_number = data.get("card_number")
+				card_number = card_number.replace(" ", "")
+				# TODO: replace with UI data collection
+				response = stripe.PaymentMethod.create(
+					type="card",
+					card={
+						"number": card_number,
+						"exp_month": int(data.get("card_expiration_date").split("-")[1]),
+						"exp_year": int(data.get("card_expiration_date").split("-")[0]),
+						"cvc": data.get("card_cvc"),
+					},
+				)
+			elif (
+				data.mode_of_payment.replace("New ", "") == "ACH"
+			):  # TODO: replace with UI data collection / mandate / verification process
+				response = stripe.PaymentMethod.create(
+					type="us_bank_account",
+					us_bank_account={
+						"account_holder_type": frappe.get_value(
+							"Customer", doc.customer, "customer_type"
+						).lower(),  # 'individual' or 'company'
+						"routing_number": str(data.get("routing_number")),
+						"account_number": str(data.get("account_number")),
+					},
+					billing_details={"name": data.get("account_holders_name"), "email": ""},
+				)
+			else:
+				return {"error": "Unsupported payment method provided."}
+
+			return {"message": "Success", "transaction_id": response.id}
+		except Exception as e:
+			try:
+				frappe.log_error(message=frappe.get_traceback(), title=f"{e.code}: {e.type}. {e.message}")
+				return {
+					"error": f"{e.code}: {e.type}. {e.message}"
+				}  # e.code has status code, e.type is one of 4 error types, e.message is a human-readable message providing more details about the error
+			except Exception as _e:  # non-Stripe error, something else went wrong
+				frappe.log_error(message=frappe.get_traceback(), title=f"{e}")
+				return {"error": f"{e}"}
+
+	def create_payment_intent(self, doc, data):
+		# For New ACH transactions, creates an un-confirmed PaymentIntent and returns the client secret
+		self.get_password(doc.company)
+		try:
+			total_to_charge = flt(
+				doc.grand_total + (data.get("additional_charges") or 0),
+				frappe.get_precision(doc.doctype, "grand_total"),
+			)
+			customer_response = self.create_party_profile(doc)
+			if customer_response.get("message") == "Success":
+				currency = frappe.defaults.get_global_default("currency").lower()
+				response = stripe.PaymentIntent.create(
+					amount=int(total_to_charge * self.currency_multiplier(currency)),
+					currency=currency,
+					customer=customer_response.get("transaction_id"),
+					description=doc.name,
+					setup_future_usage="off_session",  # Indicates this payment method will be used in future PaymentIntents and saves to Customer. off_session = can charge customer at later time, on_session = can only charge in live session
+					payment_method_types=["us_bank_account", "card"],
+					# payment_method_options={
+					# 	"us_bank_account": {
+					# 	"financial_connections": {"permissions": ["payment_method", "balances"]},
+					# 	},
+					# },
+				)
+				return {
+					"message": "Success",
+					"transaction_id": response.id,
+					"customer_profile_id": response.customer,
+					"client_secret": response.client_secret,
+				}
+			else:  # error creating customer profile
+				return customer_response
+		except Exception as e:
+			try:
+				frappe.log_error(message=frappe.get_traceback(), title=f"{e.code}: {e.type}. {e.message}")
+				return {
+					"error": f"{e.code}: {e.type}. {e.message}"
+				}  # e.code has status code, e.type is one of 4 error types, e.message is a human-readable message providing more details about the error
+			except Exception as _e:  # non-Stripe error, something else went wrong
+				frappe.log_error(message=frappe.get_traceback(), title=f"{e}")
+				return {"error": f"{e}"}
 
 
 def fetch_stripe_transactions(settings):

--- a/electronic_payments/electronic_payments/doctype/electronic_payment_settings/stripe.py
+++ b/electronic_payments/electronic_payments/doctype/electronic_payment_settings/stripe.py
@@ -12,6 +12,9 @@ from frappe.utils import cint
 from frappe.utils.data import flt
 from frappe.utils.password import get_decrypted_password
 
+from electronic_payments.electronic_payments.doctype.electronic_payment_settings.base import (
+	BaseProvider,
+)
 from electronic_payments.electronic_payments.doctype.electronic_payment_settings.common import (
 	calculate_payment_method_fees,
 	exceeds_credit_limit,
@@ -59,13 +62,21 @@ General Notes:
 """
 
 
-class Stripe:
+class Stripe(BaseProvider):
+	def __init__(self):
+		"""
+		self.provider value should match the selection text in Electronic Payment Settings
+		self.gateway value should match the selection text in Electronic Payment Profile
+		"""
+		self.provider = "Stripe"
+		self.gateway = "Stripe"
+
 	def get_password(self, company):
 		settings = frappe.get_doc("Electronic Payment Settings", {"company": company})
 		if not settings:
 			frappe.msgprint(_(f"No Electronic Payment Settings found for {company}"))
 		else:
-			api_key_field = "api_key" if settings.provider == "Stripe" else "sending_api_key"
+			api_key_field = "api_key" if settings.provider == self.provider else "sending_api_key"
 			stripe.api_key = get_decrypted_password(
 				settings.doctype, settings.name, api_key_field, raise_exception=False
 			)
@@ -129,6 +140,97 @@ class Stripe:
 		)
 		return 100 if currency not in zero_decimal else 1
 
+	def create_party_profile(self, doc, data=None):
+		party = get_party_details(doc)
+		self.get_password(doc.company)
+		try:
+			existing_party_id = get_party_profile_id(party.name, doc.company, self.provider)
+			if existing_party_id:
+				return {"message": "Success", "transaction_id": existing_party_id}
+			else:
+				response = stripe.Customer.create(name=doc.customer)
+				return {"message": "Success", "transaction_id": response.id}
+		except Exception as e:
+			try:
+				frappe.log_error(message=frappe.get_traceback(), title=f"{e.code}: {e.type}. {e.message}")
+				return {"error": f"{e.code}: {e.type}. {e.message}"}
+			except Exception as _e:  # non-Stripe error, something else went wrong
+				frappe.log_error(message=frappe.get_traceback(), title=f"{e}")
+				return {"error": f"{e}"}
+
+	def create_party_payment_profile(self, doc, data):
+		self.get_password(doc.company)
+		settings = frappe.get_doc("Electronic Payment Settings", {"company": doc.company})
+		party = get_party_details(doc)
+
+		if not data.get("party_profile_id"):
+			party_profile_id = get_party_profile_id(party.name, doc.company, self.provider)
+		else:
+			party_profile_id = data.get("party_profile_id")
+
+		try:
+			pm_response = self.create_payment_method(doc, data)
+			if pm_response.get("message") == "Success":
+				response = stripe.PaymentMethod.attach(
+					pm_response.get("transaction_id"),
+					customer=party_profile_id,
+				)
+				mop = data.mode_of_payment.replace("New ", "")
+				if mop == "Card":
+					card_number = data.get("card_number")
+					card_number = card_number.replace(" ", "")
+					last4 = card_number[-4:]
+				else:
+					account_number = data.get("account_number")
+					account_number = account_number.replace(" ", "")
+					last4 = account_number[-4:]
+
+				save_data = data.save_data in [
+					"Retain payment data for this party and process",
+					"Save payment data only",
+				]
+				payment_profile = frappe.new_doc("Electronic Payment Profile")
+				payment_profile.party_type = party.doctype
+				payment_profile.party = party.name
+				payment_profile.payment_type = mop
+				payment_profile.payment_gateway = self.gateway
+				payment_profile.reference = f"**** **** **** {last4}" if mop == "Card" else f"*{last4}"
+				payment_profile.payment_profile_id = str(response.id)
+				payment_profile.party_profile = str(party_profile_id)
+				payment_profile.retain = int(save_data)
+				payment_profile.company = doc.company
+				payment_profile.save(ignore_permissions=True)
+
+				if payment_profile.retain and settings.create_ppm:
+					mop_field = (
+						"mode_of_payment" if settings.provider == self.provider else "sending_mode_of_payment"
+					)
+					ppm = frappe.new_doc("Portal Payment Method")
+					ppm.mode_of_payment = settings.get(mop_field)
+					ppm.label = f"{mop}-{last4}"
+					ppm.default = cint(data.get("default", 0))
+					ppm.electronic_payment_profile = payment_profile.name
+					ppm.service_charge = 0
+					ppm.parent = payment_profile.party
+					ppm.parenttype = payment_profile.party_type
+					ppm.save(ignore_permissions=True)
+
+					party_obj = frappe.get_doc(party.doctype, party.name)
+					party_obj.append("portal_payment_method", ppm)
+					party_obj.save(ignore_permissions=True)
+					data.update({"ppm_name": ppm.name})
+
+				return {"message": "Success", "payment_profile_doc": payment_profile}
+			else:  # error creating the payment method
+				return pm_response
+		except Exception as e:
+			try:
+				frappe.log_error(message=frappe.get_traceback(), title=f"{e.code}: {e.type}. {e.message}")
+				return {"error": f"{e.code}: {e.type}. {e.message}"}
+			except Exception as _e:  # non-Stripe error, something else went wrong
+				frappe.log_error(message=frappe.get_traceback(), title=f"{e}")
+				return {"error": f"{e}"}
+
 	def create_payment_method(self, doc, data):
 		self.get_password(doc.company)
 		try:
@@ -160,7 +262,7 @@ class Stripe:
 					billing_details={"name": data.get("account_holders_name"), "email": ""},
 				)
 			else:
-				frappe.throw(_("Unsupported payment method provided."))
+				return {"error": "Unsupported payment method provided."}
 
 			return {"message": "Success", "transaction_id": response.id}
 		except Exception as e:
@@ -215,82 +317,6 @@ class Stripe:
 				frappe.log_error(message=frappe.get_traceback(), title=f"{e}")
 				return {"error": f"{e}"}
 
-	def process_credit_card(self, doc, data):
-		self.get_password(doc.company)
-		try:
-			pm_response = self.create_payment_method(doc, data)
-			if pm_response.get("message") == "Success":
-				currency = frappe.defaults.get_global_default("currency").lower()
-				card_number = data.get("card_number")
-				card_number = card_number.replace(" ", "")
-				payment_amount = data.get("amount") or get_payment_amount(doc, data)
-				discount_amount = 0 if data.get("amount") else get_discount_amount(doc, data)
-				if data.get("ppm_name") and not data.get("additional_charges"):
-					data.update({"additional_charges": calculate_payment_method_fees(doc, data)})
-				total_to_charge = flt(
-					payment_amount - discount_amount + data.get("additional_charges", 0),
-					frappe.get_precision(doc.doctype, "grand_total"),
-				)
-				response = stripe.PaymentIntent.create(
-					amount=int(total_to_charge * self.currency_multiplier(currency)),
-					currency=currency,
-					confirm=True,
-					description=doc.name,
-					payment_method=pm_response.get("transaction_id"),
-					# automatic_payment_methods={"enabled": True},  # Company would need to set up payment methods in their Stripe dashboard
-					# off_session=False if data.get('save_date') != 'Charge now' else True,  # Use with confirm=True and collecting payment data to charge later
-					# customer=None,  # Stripe customer ID. If provided and setup_future_usage is present, will save payment method to that customer for future use
-					# setup_future_usage='off_session',  # Indicates this payment method will be used in future PaymentIntents. Saves to Customer if present (if not, can be attached to a customer after transaction completes). off_session = can charge customer at later time, on_session = can only charge in live session
-				)
-
-				if response.status == "succeeded":
-					frappe.db.set_value(doc.doctype, doc.name, "electronic_payment_reference", str(response.id))
-					queue_method_as_admin(
-						process_electronic_payment, doc=doc, data=data, transaction_id=str(response.id)
-					)
-					return {"message": "Success", "transaction_id": response.id}
-				elif response.status == "processing":
-					# TODO: handle follow up in UI
-					return {"error": "Transaction processing"}
-				elif response.status in [
-					"requires_action",
-					"requires_confirmation",
-					"requires_capture",
-				]:
-					# TODO: requires_action needs customer authentication (handle on client-side), parameter values should bypass other statuses
-					return {"error": f'Further action required: {response.status.split("_")[-1]}'}
-				else:  # 'requires_payment_method' aka the payment attempt failed
-					return {"error": "Payment failed"}
-			else:  # error creating the payment method
-				return pm_response
-		except Exception as e:
-			try:
-				frappe.log_error(message=frappe.get_traceback(), title=f"{e.code}: {e.type}. {e.message}")
-				return {
-					"error": f"{e.code}: {e.type}. {e.message}"
-				}  # e.code has status code, e.type is one of 4 error types, e.message is a human-readable message providing more details about the error
-			except Exception as _e:  # non-Stripe error, something else went wrong
-				frappe.log_error(message=frappe.get_traceback(), title=f"{e}")
-				return {"error": f"{e}"}
-
-	def create_party_profile(self, doc, data=None):
-		party = get_party_details(doc)
-		self.get_password(doc.company)
-		try:
-			existing_party_id = get_party_profile_id(party.name, doc.company, "Stripe")
-			if existing_party_id:
-				return {"message": "Success", "transaction_id": existing_party_id}
-			else:
-				response = stripe.Customer.create(name=doc.customer)
-				return {"message": "Success", "transaction_id": response.id}
-		except Exception as e:
-			try:
-				frappe.log_error(message=frappe.get_traceback(), title=f"{e.code}: {e.type}. {e.message}")
-				return {"error": f"{e.code}: {e.type}. {e.message}"}
-			except Exception as _e:  # non-Stripe error, something else went wrong
-				frappe.log_error(message=frappe.get_traceback(), title=f"{e}")
-				return {"error": f"{e}"}
-
 	def get_party_payment_profile(self, company, electronic_payment_profile_name):
 		self.get_password(company)
 		electronic_payment_profile = frappe.get_doc(
@@ -322,7 +348,7 @@ class Stripe:
 				},
 			}
 
-	def edit_customer_payment_profile(self, company, electronic_payment_profile_name, data):
+	def edit_payment_profile(self, company, electronic_payment_profile_name, data):
 		self.get_password(company)
 
 		payment_profile = frappe.get_doc(
@@ -390,69 +416,42 @@ class Stripe:
 		else:  # error creating the payment method
 			return pm_response
 
-	def create_party_payment_profile(self, doc, data):
-		self.get_password(doc.company)
-		settings = frappe.get_doc("Electronic Payment Settings", {"company": doc.company})
-		party = get_party_details(doc)
+	def delete_payment_profile(self, company, payment_profile_id):
+		# Delete from ERPNext
+		epp_name = frappe.get_value(
+			"Electronic Payment Profile",
+			{"payment_profile_id": payment_profile_id},
+		)
+		pmm_name = frappe.get_value("Portal Payment Method", {"electronic_payment_profile": epp_name})
 
-		if not data.get("party_profile_id"):
-			party_profile_id = get_party_profile_id(party.name, doc.company, "Stripe")
-		else:
-			party_profile_id = data.get("party_profile_id")
+		if pmm_name:
+			frappe.delete_doc("Portal Payment Method", pmm_name, ignore_permissions=True)
+		frappe.delete_doc("Electronic Payment Profile", epp_name, ignore_permissions=True)
 
+		# Delete from API
+		self.get_password(company)
 		try:
-			pm_response = self.create_payment_method(doc, data)
-			if pm_response.get("message") == "Success":
-				response = stripe.PaymentMethod.attach(
-					pm_response.get("transaction_id"),
-					customer=party_profile_id,
+			response = stripe.PaymentMethod.detach(payment_profile_id)
+			return {"message": "Success"}
+		except Exception as e:
+			try:
+				frappe.log_error(message=frappe.get_traceback(), title=f"{e.code}: {e.type}. {e.message}")
+				return {"error": f"{e.code}: {e.type}. {e.message}"}
+			except Exception as _e:  # non-Stripe error, something else went wrong
+				frappe.log_error(message=frappe.get_traceback(), title=f"{e}")
+				return {"error": f"{e}"}
+
+	def delete_party_profile(self, company, party, party_profile_id):
+		self.get_password(company)
+		try:
+			response = stripe.Customer.delete(party_profile_id)
+			if response.deleted:
+				return {"message": "Success"}
+			else:
+				frappe.log_error(
+					message=frappe.get_traceback(),
+					title=f"Error deleting profile for {party}",
 				)
-				mop = data.mode_of_payment.replace("New ", "")
-				if mop == "Card":
-					card_number = data.get("card_number")
-					card_number = card_number.replace(" ", "")
-					last4 = card_number[-4:]
-				else:
-					account_number = data.get("account_number")
-					account_number = account_number.replace(" ", "")
-					last4 = account_number[-4:]
-
-				save_data = data.save_data in [
-					"Retain payment data for this party and process",
-					"Save payment data only",
-				]
-				payment_profile = frappe.new_doc("Electronic Payment Profile")
-				payment_profile.party_type = party.doctype
-				payment_profile.party = party.name
-				payment_profile.payment_type = mop
-				payment_profile.payment_gateway = "Stripe"
-				payment_profile.reference = f"**** **** **** {last4}" if mop == "Card" else f"*{last4}"
-				payment_profile.payment_profile_id = str(response.id)
-				payment_profile.party_profile = str(party_profile_id)
-				payment_profile.retain = int(save_data)
-				payment_profile.company = doc.company
-				payment_profile.save(ignore_permissions=True)
-
-				if payment_profile.retain and settings.create_ppm:
-					mop_field = "mode_of_payment" if settings.provider == "Stripe" else "sending_mode_of_payment"
-					ppm = frappe.new_doc("Portal Payment Method")
-					ppm.mode_of_payment = settings.get(mop_field)
-					ppm.label = f"{mop}-{last4}"
-					ppm.default = cint(data.get("default", 0))
-					ppm.electronic_payment_profile = payment_profile.name
-					ppm.service_charge = 0
-					ppm.parent = payment_profile.party
-					ppm.parenttype = payment_profile.party_type
-					ppm.save(ignore_permissions=True)
-
-					party_obj = frappe.get_doc(party.doctype, party.name)
-					party_obj.append("portal_payment_method", ppm)
-					party_obj.save(ignore_permissions=True)
-					data.update({"ppm_name": ppm.name})
-
-				return {"message": "Success", "payment_profile_doc": payment_profile}
-			else:  # error creating the payment method
-				return pm_response
 		except Exception as e:
 			try:
 				frappe.log_error(message=frappe.get_traceback(), title=f"{e.code}: {e.type}. {e.message}")
@@ -465,7 +464,7 @@ class Stripe:
 		self.get_password(doc.company)
 		party = get_party_details(doc)
 		if not data.get("party_profile_id"):
-			party_profile_id = get_party_profile_id(party.name, doc.company, "Stripe")
+			party_profile_id = get_party_profile_id(party.name, doc.company, self.provider)
 		else:
 			party_profile_id = data.get("party_profile_id")
 
@@ -515,13 +514,74 @@ class Stripe:
 				"requires_capture",
 			]:
 				# TODO: requires_action needs customer authentication (handle on client-side), parameter values should bypass other statuses
-				return {"error": f'Further action required: {response.status.split("_")[-1]}'}
+				return {"error": _(f'Further action required: {response.status.split("_")[-1]}')}
 			else:  # 'requires_payment_method' aka the payment attempt failed
-				return {"error": "Payment failed"}
+				return {"error": _("Payment failed")}
 		except Exception as e:
 			try:
 				frappe.log_error(message=frappe.get_traceback(), title=f"{e.code}: {e.type}. {e.message}")
-				return {"error": f"{e.code}: {e.type}. {e.message}"}
+				return {"error": _(f"{e.code}: {e.type}. {e.message}")}
+			except Exception as _e:  # non-Stripe error, something else went wrong
+				frappe.log_error(message=frappe.get_traceback(), title=f"{e}")
+				return {"error": _(f"{e}")}
+
+	def create_transfer_to_party_profile(self, doc, data, bypass_je_pe_creation=False):
+		return {"error": _("Not supported.")}
+
+	def process_credit_card(self, doc, data):
+		self.get_password(doc.company)
+		try:
+			pm_response = self.create_payment_method(doc, data)
+			if pm_response.get("message") == "Success":
+				currency = frappe.defaults.get_global_default("currency").lower()
+				card_number = data.get("card_number")
+				card_number = card_number.replace(" ", "")
+				payment_amount = data.get("amount") or get_payment_amount(doc, data)
+				discount_amount = 0 if data.get("amount") else get_discount_amount(doc, data)
+				if data.get("ppm_name") and not data.get("additional_charges"):
+					data.update({"additional_charges": calculate_payment_method_fees(doc, data)})
+				total_to_charge = flt(
+					payment_amount - discount_amount + data.get("additional_charges", 0),
+					frappe.get_precision(doc.doctype, "grand_total"),
+				)
+				response = stripe.PaymentIntent.create(
+					amount=int(total_to_charge * self.currency_multiplier(currency)),
+					currency=currency,
+					confirm=True,
+					description=doc.name,
+					payment_method=pm_response.get("transaction_id"),
+					# automatic_payment_methods={"enabled": True},  # Company would need to set up payment methods in their Stripe dashboard
+					# off_session=False if data.get('save_date') != 'Charge now' else True,  # Use with confirm=True and collecting payment data to charge later
+					# customer=None,  # Stripe customer ID. If provided and setup_future_usage is present, will save payment method to that customer for future use
+					# setup_future_usage='off_session',  # Indicates this payment method will be used in future PaymentIntents. Saves to Customer if present (if not, can be attached to a customer after transaction completes). off_session = can charge customer at later time, on_session = can only charge in live session
+				)
+
+				if response.status == "succeeded":
+					frappe.db.set_value(doc.doctype, doc.name, "electronic_payment_reference", str(response.id))
+					queue_method_as_admin(
+						process_electronic_payment, doc=doc, data=data, transaction_id=str(response.id)
+					)
+					return {"message": "Success", "transaction_id": response.id}
+				elif response.status == "processing":
+					# TODO: handle follow up in UI
+					return {"error": "Transaction processing"}
+				elif response.status in [
+					"requires_action",
+					"requires_confirmation",
+					"requires_capture",
+				]:
+					# TODO: requires_action needs customer authentication (handle on client-side), parameter values should bypass other statuses
+					return {"error": f'Further action required: {response.status.split("_")[-1]}'}
+				else:  # 'requires_payment_method' aka the payment attempt failed
+					return {"error": "Payment failed"}
+			else:  # error creating the payment method
+				return pm_response
+		except Exception as e:
+			try:
+				frappe.log_error(message=frappe.get_traceback(), title=f"{e.code}: {e.type}. {e.message}")
+				return {
+					"error": f"{e.code}: {e.type}. {e.message}"
+				}  # e.code has status code, e.type is one of 4 error types, e.message is a human-readable message providing more details about the error
 			except Exception as _e:  # non-Stripe error, something else went wrong
 				frappe.log_error(message=frappe.get_traceback(), title=f"{e}")
 				return {"error": f"{e}"}
@@ -561,49 +621,8 @@ class Stripe:
 		# No separate workflow for this in Stripe
 		self.refund_transaction(doc, data)
 
-	def delete_payment_profile(self, company, payment_profile_id):
-		# Delete from ERPNext
-		epp_name = frappe.get_value(
-			"Electronic Payment Profile",
-			{"payment_profile_id": payment_profile_id},
-		)
-		pmm_name = frappe.get_value("Portal Payment Method", {"electronic_payment_profile": epp_name})
-
-		if pmm_name:
-			frappe.delete_doc("Portal Payment Method", pmm_name, ignore_permissions=True)
-		frappe.delete_doc("Electronic Payment Profile", epp_name, ignore_permissions=True)
-
-		# Delete from API
-		self.get_password(company)
-		try:
-			response = stripe.PaymentMethod.detach(payment_profile_id)
-			return {"message": "Success"}
-		except Exception as e:
-			try:
-				frappe.log_error(message=frappe.get_traceback(), title=f"{e.code}: {e.type}. {e.message}")
-				return {"error": f"{e.code}: {e.type}. {e.message}"}
-			except Exception as _e:  # non-Stripe error, something else went wrong
-				frappe.log_error(message=frappe.get_traceback(), title=f"{e}")
-				return {"error": f"{e}"}
-
-	def delete_party_profile(self, company, party, party_profile_id):
-		self.get_password(company)
-		try:
-			response = stripe.Customer.delete(party_profile_id)
-			if response.deleted:
-				return {"message": "Success"}
-			else:
-				frappe.log_error(
-					message=frappe.get_traceback(),
-					title=f"Error deleting profile for {party}",
-				)
-		except Exception as e:
-			try:
-				frappe.log_error(message=frappe.get_traceback(), title=f"{e.code}: {e.type}. {e.message}")
-				return {"error": f"{e.code}: {e.type}. {e.message}"}
-			except Exception as _e:  # non-Stripe error, something else went wrong
-				frappe.log_error(message=frappe.get_traceback(), title=f"{e}")
-				return {"error": f"{e}"}
+	def get_transaction_details(self, company, transaction_id):
+		return {"error": _("Not supported.")}
 
 
 def fetch_stripe_transactions(settings):

--- a/electronic_payments/electronic_payments/doctype/electronic_payment_settings/wise.py
+++ b/electronic_payments/electronic_payments/doctype/electronic_payment_settings/wise.py
@@ -36,23 +36,24 @@ class Wise(BaseProvider):
 		self.gateway = "Wise"
 
 	def get_base_url_and_header(self, company):
+		"""
+		Provider-specific method for API authentication
+		"""
 		settings = frappe.get_doc("Electronic Payment Settings", {"company": company})
 		if not settings:
 			frappe.msgprint(_(f"No Electronic Payment Settings found for {company}"))
 		else:
-			api_key_field = "api_key" if settings.provider == self.provider else "sending_api_key"
-			endpoint_field = "endpoint" if settings.provider == self.provider else "sending_endpoint"
 			api_key = get_decrypted_password(
-				settings.doctype, settings.name, api_key_field, raise_exception=False
+				settings.doctype, settings.name, "wise_sending_api_key", raise_exception=False
 			)
-			base_url = settings.get(endpoint_field)
+			base_url = settings.wise_sending_endpoint
 			headers = {"Authorization": f"Bearer {api_key}", "Content-Type": "application/json"}
 			return base_url, headers
 
 	def process_transaction(self, doc, data):
 		"""
-		Overrides BaseProvider class method because Wise's payment flow requiring quotes and
-		funding steps differ significantly
+		Overrides BaseProvider class method because Wise's payment flow (requiring quotes and
+		funding steps) differs significantly from other providers
 		"""
 		mop = data.mode_of_payment.replace("New ", "")
 		party = get_party_details(doc)
@@ -109,169 +110,16 @@ class Wise(BaseProvider):
 
 		return response
 
-	def create_party_profile(
-		self, doc
-	):  # Never called because process_transaction overrides BaseProvider
-		"""Not used in Wise"""
+	def create_party_profile(self, doc):
+		"""
+		Not used in Wise - never called because process_transaction overrides BaseProvider
+		"""
 		return {"message": "Success", "transaction_id": None}
-
-	def process_credit_card(self, doc, data):
-		"""
-		Currently unsupported - replace with code to generate a Wise payment request link
-		"""
-		return {"error": _("Not supported")}
-
-	def get_profiles(self, company):
-		try:
-			base_url, headers = self.get_base_url_and_header(company)
-			response = requests.get(
-				urljoin(base_url, "/v2/profiles"),
-				headers=headers,
-				timeout=10,
-			)
-			response.raise_for_status()
-			r = response.json()
-			if r:
-				profile_data = []
-				for profile in r:
-					p_type = profile["type"].lower()
-					name = profile["businessName"] if p_type == "business" else profile["fullName"]
-					profile_data.append(f"{p_type.title()} Account for {name} has ID: {profile['id']}")
-
-				return {"message": "Success", "data": profile_data}
-
-		except HTTPError as e_http:
-			err_msg = " ".join([err.get("message") for err in response.json().get("errors", [])])
-			frappe.log_error(
-				message=f"{response.json()}\n\n{e_http}\n\n{frappe.get_traceback()}",
-				title="Error requesting a list of profiles associated with this Wise account.",
-			)
-			return {"error": f"{err_msg}"}
-
-		except requests.exceptions.RequestException as e:
-			frappe.log_error(
-				message=f"{e}\n\n{frappe.get_traceback()}",
-				title="Error requesting a list of profiles associated with this Wise account.",
-			)
-			return {"error": f"{e}"}
-
-	def create_quote(self, doc, data):
-		settings = frappe.get_doc("Electronic Payment Settings", {"company": doc.company})
-		merch_id_field = "ref_id" if settings.provider == self.provider else "sending_ref_id"
-		profile_id = settings.get(merch_id_field)
-
-		payment_amount = data.get("amount") or get_payment_amount(doc, data)
-		discount_amount = 0 if data.get("amount") else get_discount_amount(doc, data)
-		if data.get("ppm_name") and not data.get("additional_charges"):
-			data.update({"additional_charges": calculate_payment_method_fees(doc, data)})
-		total_to_charge = flt(
-			payment_amount - discount_amount + data.get("additional_charges", 0),
-			frappe.get_precision(doc.doctype, "grand_total"),
-		)
-
-		try:
-			base_url, headers = self.get_base_url_and_header(doc.company)
-			response = requests.post(
-				urljoin(base_url, f"/v3/profiles/{profile_id}/quotes"),
-				headers=headers,
-				timeout=10,
-				data=json.dumps(
-					{
-						"sourceCurrency": frappe.defaults.get_global_default("currency"),
-						"targetCurrency": doc.currency,
-						"sourceAmount": None,
-						"targetAmount": total_to_charge,
-						"payOut": "BANK_TRANSFER",
-						"preferredPayIn": "BANK_TRANSFER",  # TODO: give user choice? BALANCE if funding via multi-currency balance
-						"targetAccount": data.get("payment_profile_id"),
-						"pricingConfiguration": {},  # required when configured in client ID
-					}
-				),
-			)
-			response.raise_for_status()
-			r = response.json()
-			if r.get("id"):
-				return {
-					"message": "Success",
-					"quote_id": r["id"],
-					"target_amount": total_to_charge,
-					"quotes": r.get("paymentOptions"),
-				}
-			else:
-				return {"error": "No quote payment options found."}
-
-		except HTTPError as e_http:
-			err_msg = " ".join([err.get("message") for err in response.json().get("errors", [])])
-			frappe.log_error(
-				message=f"{response.json()}\n\n{e_http}\n\n{frappe.get_traceback()}",
-				title="Error trying to create a Quote.",
-			)
-			return {"error": f"{err_msg}"}
-
-		except requests.exceptions.RequestException as e:
-			frappe.log_error(
-				message=f"{e}\n\n{frappe.get_traceback()}",
-				title="Request error while trying to create a Quote.",
-			)
-			return {"error": f"{e}"}
-
-	def edit_payment_profile(self, company, electronic_payment_profile_name, data):
-		# Per docs, can't edit an existing recipient account - must delete, then re-add
-		return {
-			"error": _(
-				"Wise does not support editing payment methods. Please delete the payment method then re-create it."
-			)
-		}
-
-	def get_party_payment_profile(self, company, electronic_payment_profile_name):
-		party, payment_profile_id = frappe.get_value(
-			"Electronic Payment Profile",
-			{"name": electronic_payment_profile_name},
-			["party", "payment_profile_id"],
-		)
-		try:
-			base_url, headers = self.get_base_url_and_header(company)
-			response = requests.get(
-				urljoin(base_url, f"/v2/accounts/{payment_profile_id}"),
-				headers=headers,
-				timeout=10,
-			)
-			response.raise_for_status()
-			r = response.json()
-			if r.get("id"):
-				return {
-					"message": "Success",
-					"data": {
-						"first_name": r.get("name", {}).get("givenName"),
-						"last_name": r.get("name", {}).get("familyName"),
-						"account_type": r.get("details", {}).get("accountType", "").title(),
-						"routing_number": str(r.get("details", {}).get("abartn", "")),
-						"account_number": str(r.get("details", {}).get("accountNumber", "")),
-						"name_on_account": r.get("name", {}).get("fullName"),
-						"echeck_type": None,
-					},
-				}
-
-		except HTTPError as e_http:
-			err_msg = " ".join([err.get("message") for err in response.json().get("errors", [])])
-			frappe.log_error(
-				message=f"{response.json()}\n\n{e_http}\n\n{frappe.get_traceback()}",
-				title=f"Error collecting payment profile for {party}",
-			)
-			return {"error": f"{err_msg}"}
-
-		except requests.exceptions.RequestException as e:
-			frappe.log_error(
-				message=f"{e}\n\n{frappe.get_traceback()}",
-				title=f"Request error collecting payment profile for {party}",
-			)
-			return {"error": f"{e}"}
 
 	def create_party_payment_profile(self, doc, data):
 		party = get_party_details(doc)
 		settings = frappe.get_doc("Electronic Payment Settings", {"company": doc.company})
-		merch_id_field = "ref_id" if settings.provider == self.provider else "sending_ref_id"
-		profile_id = settings.get(merch_id_field)
+		profile_id = settings.wise_sending_profile_id
 		mop = data.mode_of_payment.replace("New ", "")
 
 		try:
@@ -358,13 +206,258 @@ class Wise(BaseProvider):
 			)
 			return {"error": f"{e}"}
 
-	def charge_party_profile(self, doc, data):
+	def get_party_payment_profile(self, company, electronic_payment_profile_name):
+		party, payment_profile_id = frappe.get_value(
+			"Electronic Payment Profile",
+			{"name": electronic_payment_profile_name},
+			["party", "payment_profile_id"],
+		)
+		try:
+			base_url, headers = self.get_base_url_and_header(company)
+			response = requests.get(
+				urljoin(base_url, f"/v2/accounts/{payment_profile_id}"),
+				headers=headers,
+				timeout=10,
+			)
+			response.raise_for_status()
+			r = response.json()
+			if r.get("id"):
+				return {
+					"message": "Success",
+					"data": {
+						"first_name": r.get("name", {}).get("givenName"),
+						"last_name": r.get("name", {}).get("familyName"),
+						"account_type": r.get("details", {}).get("accountType", "").title(),
+						"routing_number": str(r.get("details", {}).get("abartn", "")),
+						"account_number": str(r.get("details", {}).get("accountNumber", "")),
+						"name_on_account": r.get("name", {}).get("fullName"),
+						"echeck_type": None,
+					},
+				}
+
+		except HTTPError as e_http:
+			err_msg = " ".join([err.get("message") for err in response.json().get("errors", [])])
+			frappe.log_error(
+				message=f"{response.json()}\n\n{e_http}\n\n{frappe.get_traceback()}",
+				title=f"Error collecting payment profile for {party}",
+			)
+			return {"error": f"{err_msg}"}
+
+		except requests.exceptions.RequestException as e:
+			frappe.log_error(
+				message=f"{e}\n\n{frappe.get_traceback()}",
+				title=f"Request error collecting payment profile for {party}",
+			)
+			return {"error": f"{e}"}
+
+	def edit_payment_profile(self, company, electronic_payment_profile_name, data):
+		# Per docs, can't edit an existing recipient account - must delete, then re-add
+		return {
+			"error": _(
+				"Wise does not support editing payment methods. Please delete the payment method then re-create it."
+			)
+		}
+
+	def delete_payment_profile(self, company, payment_profile_id):
+		# Delete from ERPNext
+		epp_name, party = frappe.get_value(
+			"Electronic Payment Profile",
+			{"payment_profile_id": payment_profile_id},
+			["name", "party"],
+		)
+		pmm_name = frappe.get_value("Portal Payment Method", {"electronic_payment_profile": epp_name})
+
+		frappe.delete_doc("Portal Payment Method", pmm_name, ignore_permissions=True)
+		frappe.delete_doc("Electronic Payment Profile", epp_name, ignore_permissions=True)
+
+		# Delete from API
+		try:
+			base_url, headers = self.get_base_url_and_header(company)
+			response = requests.delete(
+				urljoin(base_url, f"/v2/accounts/{payment_profile_id}"),
+				headers=headers,
+				timeout=10,
+			)
+			response.raise_for_status()
+			return {"message": "Success"}
+
+		except HTTPError as e_http:
+			err_msg = " ".join([err.get("message") for err in response.json().get("errors", [])])
+			frappe.log_error(
+				message=f"{response.json()}\n\n{e_http}\n\n{frappe.get_traceback()}",
+				title=f"Error deleting payment profile for {party}",
+			)
+			return {"error": f"{err_msg}"}
+
+		except requests.exceptions.RequestException as e:
+			frappe.log_error(
+				message=f"{e}\n\n{frappe.get_traceback()}",
+				title=f"Request error deleting payment profile for {party}",
+			)
+			return {"error": f"{e}"}
+
+	def delete_party_profile(self, company, party, party_profile_id):
+		# Not used in Wise
+		return {"message": "Success"}
+
+	def process_credit_card(self, doc, data):
+		"""
+		Currently unsupported - replace with code to generate a Wise payment request link
+		"""
 		return {"error": _("Not supported")}
+
+	def charge_party_profile(self, doc, data):
+		"""
+		Currently unsupported - replace with code to generate a Wise payment request link
+		"""
+		return {"error": _("Not supported")}
+
+	def create_transfer_to_party_profile(self, doc, data):
+		party = get_party_details(doc)
+		payment_profile_id = data.get("payment_profile_id")
+		quote_id = data.get("quote_id")
+		try:
+			base_url, headers = self.get_base_url_and_header(doc.company)
+			customer_txn_id_uuid = str(uuid.uuid4())  # TODO: save to doc if transfer fails?
+			response = requests.post(
+				urljoin(base_url, "/v1/transfers"),
+				headers=headers,
+				timeout=10,
+				data=json.dumps(
+					{
+						"targetAccount": payment_profile_id,
+						"quoteUuid": quote_id,
+						"customerTransactionId": customer_txn_id_uuid,
+						"details": {
+							"reference": doc.name[-10:],
+							"transferPurpose": "verification.transfers.purpose.pay.bills",
+						},
+					}
+				),
+			)
+			response.raise_for_status()
+			r = response.json()
+			if r.get("id"):
+				transaction_id = r.get("id")
+				if not frappe.get_value(
+					"Electronic Payment Profile",
+					{"party": party.name, "payment_profile_id": payment_profile_id},
+					"retain",
+				):
+					frappe.get_doc(
+						"Electronic Payment Profile",
+						{"party": party.name, "payment_profile_id": payment_profile_id},
+					).delete()
+
+					try:
+						del_response = requests.delete(
+							urljoin(base_url, f"/v2/accounts/{payment_profile_id}"),
+							headers=headers,
+							timeout=10,
+						)
+						del_response.raise_for_status()
+
+					# If deletion on API-side fails, log error but continue processing
+					except HTTPError as e_http:
+						err_msg = " ".join([err.get("message") for err in del_response.json().get("errors", [])])
+						frappe.log_error(
+							message=f"{del_response.json()}\n\n{e_http}\n\n{frappe.get_traceback()}",
+							title=f"Error deleting payment profile used for {doc.name}",
+						)
+
+					except requests.exceptions.RequestException as e:
+						frappe.log_error(
+							message=f"{e}\n\n{frappe.get_traceback()}",
+							title=f"Request error deleting payment profile used for {doc.name}",
+						)
+
+				queue_method_as_admin(
+					process_electronic_payment,
+					doc=doc,
+					data=data,
+					transaction_id=str(transaction_id),
+				)
+				return {
+					"message": "Success",
+					"transaction_id": str(transaction_id),
+				}
+
+		except HTTPError as e_http:
+			err_msg = " ".join([err.get("message") for err in response.json().get("errors", [])])
+			frappe.log_error(
+				message=f"{response.json()}\n\n{e_http}\n\n{frappe.get_traceback()}",
+				title="Error creating Transfer.",
+			)
+			return {"error": f"{err_msg}"}
+
+		except requests.exceptions.RequestException as e:
+			frappe.log_error(
+				message=f"{e}\n\n{frappe.get_traceback()}", title="Request error creating Transfer."
+			)
+			return {"error": f"{e}"}
+
+	def create_quote(self, doc, data):
+		settings = frappe.get_doc("Electronic Payment Settings", {"company": doc.company})
+		profile_id = settings.wise_sending_profile_id
+
+		payment_amount = data.get("amount") or get_payment_amount(doc, data)
+		discount_amount = 0 if data.get("amount") else get_discount_amount(doc, data)
+		if data.get("ppm_name") and not data.get("additional_charges"):
+			data.update({"additional_charges": calculate_payment_method_fees(doc, data)})
+		total_to_charge = flt(
+			payment_amount - discount_amount + data.get("additional_charges", 0),
+			frappe.get_precision(doc.doctype, "grand_total"),
+		)
+
+		try:
+			base_url, headers = self.get_base_url_and_header(doc.company)
+			response = requests.post(
+				urljoin(base_url, f"/v3/profiles/{profile_id}/quotes"),
+				headers=headers,
+				timeout=10,
+				data=json.dumps(
+					{
+						"sourceCurrency": frappe.defaults.get_global_default("currency"),
+						"targetCurrency": doc.currency,
+						"sourceAmount": None,
+						"targetAmount": total_to_charge,
+						"payOut": "BANK_TRANSFER",
+						"preferredPayIn": "BANK_TRANSFER",  # TODO: give user choice? BALANCE if funding via multi-currency balance
+						"targetAccount": data.get("payment_profile_id"),
+						"pricingConfiguration": {},  # required when configured in client ID
+					}
+				),
+			)
+			response.raise_for_status()
+			r = response.json()
+			if r.get("id"):
+				return {
+					"message": "Success",
+					"quote_id": r["id"],
+					"target_amount": total_to_charge,
+					"quotes": r.get("paymentOptions"),
+				}
+			else:
+				return {"error": "No quote payment options found."}
+
+		except HTTPError as e_http:
+			err_msg = " ".join([err.get("message") for err in response.json().get("errors", [])])
+			frappe.log_error(
+				message=f"{response.json()}\n\n{e_http}\n\n{frappe.get_traceback()}",
+				title="Error trying to create a Quote.",
+			)
+			return {"error": f"{err_msg}"}
+
+		except requests.exceptions.RequestException as e:
+			frappe.log_error(
+				message=f"{e}\n\n{frappe.get_traceback()}",
+				title="Request error while trying to create a Quote.",
+			)
+			return {"error": f"{e}"}
 
 	def create_batch_group(self, doc, data):
 		settings = frappe.get_doc("Electronic Payment Settings", {"company": doc.company})
-		merch_id_field = "ref_id" if settings.provider == self.provider else "sending_ref_id"
-		profile_id = settings.get(merch_id_field)
+		profile_id = settings.wise_sending_profile_id
 		pmt_term = f"|{data.get('payment_term')}" if data.get("payment_term") else ""
 		batch_name = f"{doc.name}{pmt_term}"
 		try:
@@ -402,8 +495,7 @@ class Wise(BaseProvider):
 
 	def create_batch_group_transfer(self, doc, data):
 		settings = frappe.get_doc("Electronic Payment Settings", {"company": doc.company})
-		merch_id_field = "ref_id" if settings.provider == self.provider else "sending_ref_id"
-		profile_id = settings.get(merch_id_field)
+		profile_id = settings.wise_sending_profile_id
 		payment_profile_id = data.get("payment_profile_id")
 		batch_id = data.get("batch_id")
 		quote_id = data.get("quote_id")
@@ -449,8 +541,7 @@ class Wise(BaseProvider):
 
 	def complete_batch_group(self, doc, data):
 		settings = frappe.get_doc("Electronic Payment Settings", {"company": doc.company})
-		merch_id_field = "ref_id" if settings.provider == self.provider else "sending_ref_id"
-		profile_id = settings.get(merch_id_field)
+		profile_id = settings.wise_sending_profile_id
 		batch_id = data.get("batch_id")
 		try:
 			base_url, headers = self.get_base_url_and_header(doc.company)
@@ -518,8 +609,7 @@ class Wise(BaseProvider):
 		party = get_party_details(doc)
 		payment_profile_id = data.get("payment_profile_id")
 		settings = frappe.get_doc("Electronic Payment Settings", {"company": doc.company})
-		merch_id_field = "ref_id" if settings.provider == self.provider else "sending_ref_id"
-		profile_id = settings.get(merch_id_field)
+		profile_id = settings.wise_sending_profile_id
 		batch_id = data.get("batch_id")
 		account_id = settings.wise_linked_bank_account_id
 		fees = flt(
@@ -605,90 +695,6 @@ class Wise(BaseProvider):
 			frappe.log_error(
 				message=f"{e}\n\n{frappe.get_traceback()}",
 				title="Error funding batch group transfer with a direct debit account.",
-			)
-			return {"error": f"{e}"}
-
-	def create_transfer_to_party_profile(self, doc, data):
-		party = get_party_details(doc)
-		payment_profile_id = data.get("payment_profile_id")
-		quote_id = data.get("quote_id")
-		try:
-			base_url, headers = self.get_base_url_and_header(doc.company)
-			customer_txn_id_uuid = str(uuid.uuid4())  # TODO: save to doc if transfer fails?
-			response = requests.post(
-				urljoin(base_url, "/v1/transfers"),  # assumes regular transfer
-				headers=headers,
-				timeout=10,
-				data=json.dumps(
-					{
-						"targetAccount": payment_profile_id,
-						"quoteUuid": quote_id,
-						"customerTransactionId": customer_txn_id_uuid,
-						"details": {
-							"reference": doc.name[-10:],
-							"transferPurpose": "verification.transfers.purpose.pay.bills",
-						},
-					}
-				),
-			)
-			response.raise_for_status()
-			r = response.json()
-			if r.get("id"):
-				transaction_id = r.get("id")
-				if not frappe.get_value(
-					"Electronic Payment Profile",
-					{"party": party.name, "payment_profile_id": payment_profile_id},
-					"retain",
-				):
-					frappe.get_doc(
-						"Electronic Payment Profile",
-						{"party": party.name, "payment_profile_id": payment_profile_id},
-					).delete()
-
-					try:
-						del_response = requests.delete(
-							urljoin(base_url, f"/v2/accounts/{payment_profile_id}"),
-							headers=headers,
-							timeout=10,
-						)
-						del_response.raise_for_status()
-
-					# If deletion on API-side fails, log error but continue processing
-					except HTTPError as e_http:
-						err_msg = " ".join([err.get("message") for err in del_response.json().get("errors", [])])
-						frappe.log_error(
-							message=f"{del_response.json()}\n\n{e_http}\n\n{frappe.get_traceback()}",
-							title=f"Error deleting payment profile used for {doc.name}",
-						)
-
-					except requests.exceptions.RequestException as e:
-						frappe.log_error(
-							message=f"{e}\n\n{frappe.get_traceback()}",
-							title=f"Request error deleting payment profile used for {doc.name}",
-						)
-
-				queue_method_as_admin(
-					process_electronic_payment,
-					doc=doc,
-					data=data,
-					transaction_id=str(transaction_id),
-				)
-				return {
-					"message": "Success",
-					"transaction_id": str(transaction_id),
-				}
-
-		except HTTPError as e_http:
-			err_msg = " ".join([err.get("message") for err in response.json().get("errors", [])])
-			frappe.log_error(
-				message=f"{response.json()}\n\n{e_http}\n\n{frappe.get_traceback()}",
-				title="Error creating Transfer.",
-			)
-			return {"error": f"{err_msg}"}
-
-		except requests.exceptions.RequestException as e:
-			frappe.log_error(
-				message=f"{e}\n\n{frappe.get_traceback()}", title="Request error creating Transfer."
 			)
 			return {"error": f"{e}"}
 
@@ -813,47 +819,39 @@ class Wise(BaseProvider):
 			)
 			return {"error": f"{e}"}
 
-	def delete_payment_profile(self, company, payment_profile_id):
-		# Delete from ERPNext
-		epp_name, party = frappe.get_value(
-			"Electronic Payment Profile",
-			{"payment_profile_id": payment_profile_id},
-			["name", "party"],
-		)
-		pmm_name = frappe.get_value("Portal Payment Method", {"electronic_payment_profile": epp_name})
-
-		frappe.delete_doc("Portal Payment Method", pmm_name, ignore_permissions=True)
-		frappe.delete_doc("Electronic Payment Profile", epp_name, ignore_permissions=True)
-
-		# Delete from API
+	def get_profiles(self, company):
 		try:
 			base_url, headers = self.get_base_url_and_header(company)
-			response = requests.delete(
-				urljoin(base_url, f"/v2/accounts/{payment_profile_id}"),
+			response = requests.get(
+				urljoin(base_url, "/v2/profiles"),
 				headers=headers,
 				timeout=10,
 			)
 			response.raise_for_status()
-			return {"message": "Success"}
+			r = response.json()
+			if r:
+				profile_data = []
+				for profile in r:
+					p_type = profile["type"].lower()
+					name = profile["businessName"] if p_type == "business" else profile["fullName"]
+					profile_data.append(f"{p_type.title()} Account for {name} has ID: {profile['id']}")
+
+				return {"message": "Success", "data": profile_data}
 
 		except HTTPError as e_http:
 			err_msg = " ".join([err.get("message") for err in response.json().get("errors", [])])
 			frappe.log_error(
 				message=f"{response.json()}\n\n{e_http}\n\n{frappe.get_traceback()}",
-				title=f"Error deleting payment profile for {party}",
+				title="Error requesting a list of profiles associated with this Wise account.",
 			)
 			return {"error": f"{err_msg}"}
 
 		except requests.exceptions.RequestException as e:
 			frappe.log_error(
 				message=f"{e}\n\n{frappe.get_traceback()}",
-				title=f"Request error deleting payment profile for {party}",
+				title="Error requesting a list of profiles associated with this Wise account.",
 			)
 			return {"error": f"{e}"}
-
-	def delete_party_profile(self, company, party, party_profile_id):
-		# Not used in Wise
-		return {"message": "Success"}
 
 	def create_direct_debit_account(self, company, data):
 		"""
@@ -862,7 +860,7 @@ class Wise(BaseProvider):
 		"routing_number", "account_number", and "account_type" (either "Checking" or "Savings")
 		"""
 		settings = frappe.get_doc("Electronic Payment Settings", {"company": company})
-		profile_id = settings.sending_ref_id
+		profile_id = settings.wise_sending_profile_id
 		try:
 			base_url, headers = self.get_base_url_and_header(company)
 			response = requests.post(
@@ -909,7 +907,7 @@ class Wise(BaseProvider):
 
 	def get_direct_debit_accounts(self, company):
 		settings = frappe.get_doc("Electronic Payment Settings", {"company": company})
-		profile_id = settings.sending_ref_id
+		profile_id = settings.wise_sending_profile_id
 		account_type = settings.wise_bank_account_type.upper()
 		account_currency = settings.wise_bank_account_currency
 		try:

--- a/electronic_payments/electronic_payments/doctype/electronic_payment_settings/wise.py
+++ b/electronic_payments/electronic_payments/doctype/electronic_payment_settings/wise.py
@@ -12,6 +12,9 @@ from frappe.utils import cint, flt
 from frappe.utils.password import get_decrypted_password
 from requests.exceptions import HTTPError
 
+from electronic_payments.electronic_payments.doctype.electronic_payment_settings.base import (
+	BaseProvider,
+)
 from electronic_payments.electronic_payments.doctype.electronic_payment_settings.common import (
 	calculate_payment_method_fees,
 	exceeds_credit_limit,
@@ -23,14 +26,22 @@ from electronic_payments.electronic_payments.doctype.electronic_payment_settings
 )
 
 
-class Wise:
+class Wise(BaseProvider):
+	def __init__(self):
+		"""
+		self.provider value should match the selection text in Electronic Payment Settings
+		self.gateway value should match the selection text in Electronic Payment Profile
+		"""
+		self.provider = "Wise"
+		self.gateway = "Wise"
+
 	def get_base_url_and_header(self, company):
 		settings = frappe.get_doc("Electronic Payment Settings", {"company": company})
 		if not settings:
 			frappe.msgprint(_(f"No Electronic Payment Settings found for {company}"))
 		else:
-			api_key_field = "api_key" if settings.provider == "Wise" else "sending_api_key"
-			endpoint_field = "endpoint" if settings.provider == "Wise" else "sending_endpoint"
+			api_key_field = "api_key" if settings.provider == self.provider else "sending_api_key"
+			endpoint_field = "endpoint" if settings.provider == self.provider else "sending_endpoint"
 			api_key = get_decrypted_password(
 				settings.doctype, settings.name, api_key_field, raise_exception=False
 			)
@@ -39,10 +50,14 @@ class Wise:
 			return base_url, headers
 
 	def process_transaction(self, doc, data):
+		"""
+		Overrides BaseProvider class method because Wise's payment flow requiring quotes and
+		funding steps differ significantly
+		"""
 		mop = data.mode_of_payment.replace("New ", "")
 		party = get_party_details(doc)
 		settings = frappe.get_doc("Electronic Payment Settings", {"company": doc.company})
-		use_batch = settings.sending_provider == "Wise" and settings.wise_linked_bank_account_id
+		use_batch = settings.sending_provider == self.provider and settings.wise_linked_bank_account_id
 		save_only = data.save_data == "Save payment data only"
 
 		if party.doctype == "Customer" or (mop == "Card" and data.get("save_data") == "Charge now"):
@@ -94,6 +109,12 @@ class Wise:
 
 		return response
 
+	def create_party_profile(
+		self, doc
+	):  # Never called because process_transaction overrides BaseProvider
+		"""Not used in Wise"""
+		return {"message": "Success", "transaction_id": None}
+
 	def process_credit_card(self, doc, data):
 		"""
 		Currently unsupported - replace with code to generate a Wise payment request link
@@ -136,7 +157,7 @@ class Wise:
 
 	def create_quote(self, doc, data):
 		settings = frappe.get_doc("Electronic Payment Settings", {"company": doc.company})
-		merch_id_field = "ref_id" if settings.provider == "Wise" else "sending_ref_id"
+		merch_id_field = "ref_id" if settings.provider == self.provider else "sending_ref_id"
 		profile_id = settings.get(merch_id_field)
 
 		payment_amount = data.get("amount") or get_payment_amount(doc, data)
@@ -194,7 +215,7 @@ class Wise:
 			)
 			return {"error": f"{e}"}
 
-	def edit_customer_payment_profile(self, company, electronic_payment_profile_name, data):
+	def edit_payment_profile(self, company, electronic_payment_profile_name, data):
 		# Per docs, can't edit an existing recipient account - must delete, then re-add
 		return {
 			"error": _(
@@ -249,7 +270,7 @@ class Wise:
 	def create_party_payment_profile(self, doc, data):
 		party = get_party_details(doc)
 		settings = frappe.get_doc("Electronic Payment Settings", {"company": doc.company})
-		merch_id_field = "ref_id" if settings.provider == "Wise" else "sending_ref_id"
+		merch_id_field = "ref_id" if settings.provider == self.provider else "sending_ref_id"
 		profile_id = settings.get(merch_id_field)
 		mop = data.mode_of_payment.replace("New ", "")
 
@@ -296,7 +317,7 @@ class Wise:
 				payment_profile.party_type = party.doctype
 				payment_profile.party = party.name
 				payment_profile.payment_type = mop
-				payment_profile.payment_gateway = "Wise"
+				payment_profile.payment_gateway = self.gateway
 				payment_profile.reference = f"*{last4}"
 				payment_profile.payment_profile_id = str(r.get("id"))
 				payment_profile.party_profile = None  # Not used in Wise
@@ -306,7 +327,7 @@ class Wise:
 
 				if payment_profile.retain and settings.create_ppm:
 					ppm = frappe.new_doc("Portal Payment Method")
-					ppm.mode_of_payment = f"Wise {mop}"
+					ppm.mode_of_payment = f"{self.provider} {mop}"
 					ppm.label = f"{mop}-{last4}"
 					ppm.default = cint(data.get("default", 0))
 					ppm.electronic_payment_profile = payment_profile.name
@@ -342,7 +363,7 @@ class Wise:
 
 	def create_batch_group(self, doc, data):
 		settings = frappe.get_doc("Electronic Payment Settings", {"company": doc.company})
-		merch_id_field = "ref_id" if settings.provider == "Wise" else "sending_ref_id"
+		merch_id_field = "ref_id" if settings.provider == self.provider else "sending_ref_id"
 		profile_id = settings.get(merch_id_field)
 		pmt_term = f"|{data.get('payment_term')}" if data.get("payment_term") else ""
 		batch_name = f"{doc.name}{pmt_term}"
@@ -381,7 +402,7 @@ class Wise:
 
 	def create_batch_group_transfer(self, doc, data):
 		settings = frappe.get_doc("Electronic Payment Settings", {"company": doc.company})
-		merch_id_field = "ref_id" if settings.provider == "Wise" else "sending_ref_id"
+		merch_id_field = "ref_id" if settings.provider == self.provider else "sending_ref_id"
 		profile_id = settings.get(merch_id_field)
 		payment_profile_id = data.get("payment_profile_id")
 		batch_id = data.get("batch_id")
@@ -428,7 +449,7 @@ class Wise:
 
 	def complete_batch_group(self, doc, data):
 		settings = frappe.get_doc("Electronic Payment Settings", {"company": doc.company})
-		merch_id_field = "ref_id" if settings.provider == "Wise" else "sending_ref_id"
+		merch_id_field = "ref_id" if settings.provider == self.provider else "sending_ref_id"
 		profile_id = settings.get(merch_id_field)
 		batch_id = data.get("batch_id")
 		try:
@@ -497,7 +518,7 @@ class Wise:
 		party = get_party_details(doc)
 		payment_profile_id = data.get("payment_profile_id")
 		settings = frappe.get_doc("Electronic Payment Settings", {"company": doc.company})
-		merch_id_field = "ref_id" if settings.provider == "Wise" else "sending_ref_id"
+		merch_id_field = "ref_id" if settings.provider == self.provider else "sending_ref_id"
 		profile_id = settings.get(merch_id_field)
 		batch_id = data.get("batch_id")
 		account_id = settings.wise_linked_bank_account_id

--- a/electronic_payments/tests/setup.py
+++ b/electronic_payments/tests/setup.py
@@ -938,7 +938,7 @@ def create_electronic_payment_settings(settings):
 			"provider": "Mercury",
 			"endpoint": "https://api-sandbox.mercury.com",
 			"api_key": os.environ.get("MERCURY_API_KEY"),
-			"merchant_id": os.environ.get("MERCURY_ACCOUNT_ID"),
+			"account_id": os.environ.get("MERCURY_ACCOUNT_ID"),
 		},
 		"s": {
 			"check": stripe_present,
@@ -950,7 +950,7 @@ def create_electronic_payment_settings(settings):
 			"provider": "Wise",
 			"endpoint": "https://api.sandbox.transferwise.tech",
 			"api_key": os.environ.get("WISE_API_KEY"),
-			"merchant_id": os.environ.get("WISE_ACCOUNT_ID"),
+			"profile_id": os.environ.get("WISE_ACCOUNT_ID"),
 		},
 	}
 	pa_code = settings.get("provider")
@@ -983,10 +983,6 @@ def create_electronic_payment_settings(settings):
 	else:
 		eps.enable_accepting = 1
 		eps.provider = provider_mapping[pa_code]["provider"]
-		eps.ref_id = provider_mapping[pa_code].get("merchant_id")
-		eps.endpoint = provider_mapping[pa_code].get("endpoint")
-		eps.api_key = provider_mapping[pa_code]["api_key"]
-		eps.transaction_key = provider_mapping[pa_code].get("transaction_key")
 		eps.deposit_account = "1201 - Primary Checking - CFC"
 		eps.accepting_fee_account = "5223 - Electronic Payments Provider Fees - CFC"
 		eps.accepting_clearing_account = "1320 - Electronic Payments Receivable - CFC"
@@ -994,8 +990,21 @@ def create_electronic_payment_settings(settings):
 			"Account", {"name": ["like", "%Sales - CFC%"]}, "name"
 		)
 
+		# Provider-specific fields
+		if pa_code == "a":
+			eps.authorize_accepting_endpoint = provider_mapping[pa_code]["endpoint"]
+			eps.authorize_accepting_api_key = provider_mapping[pa_code]["api_key"]
+			eps.authorize_accepting_transaction_key = provider_mapping[pa_code]["transaction_key"]
+		elif pa_code == "s":
+			eps.stripe_accepting_api_key = provider_mapping[pa_code]["api_key"]
+
 	if not ps_code:
 		eps.enable_sending = 0
+	elif ps_code and not provider_mapping[ps_code]["check"]:
+		eps.enable_sending = 0
+		print(
+			f"No API Keys found for given sending provider: {provider_mapping[ps_code]['provider']}. Settings will not enable sending payments - this may be changed manually in the Electronic Payments Settings doc."
+		)
 	elif ps_code == "m" and not os.environ.get("MERCURY_ACCOUNT_ID"):
 		eps.enable_sending = 0
 		print(
@@ -1006,24 +1015,30 @@ def create_electronic_payment_settings(settings):
 		print(
 			"No Wise profile ID found - this is required to create a Settings document. Settings will not enable sending payments - enter your API credentials manually, click save, then collect the ID from the displayed options."
 		)
-	elif ps_code and not provider_mapping[ps_code]["check"]:
-		eps.enable_sending = 0
-		print(
-			f"No API Keys found for given sending provider: {provider_mapping[ps_code]['provider']}. Settings will not enable sending payments - this may be changed manually in the Electronic Payments Settings doc."
-		)
 	else:
 		eps.enable_sending = 1
 		eps.sending_provider = provider_mapping[ps_code]["provider"]
-		eps.sending_ref_id = provider_mapping[ps_code].get("merchant_id")
-		eps.sending_endpoint = provider_mapping[ps_code].get("endpoint")
-		eps.sending_api_key = provider_mapping[ps_code]["api_key"]
-		eps.sending_transaction_key = provider_mapping[ps_code].get("transaction_key")
 		eps.withdrawal_account = "1201 - Primary Checking - CFC"
 		eps.sending_fee_account = "5223 - Electronic Payments Provider Fees - CFC"
 		eps.sending_clearing_account = "2130 - Electronic Payments Payable - CFC"
 		eps.sending_payment_discount_account = frappe.get_value(
 			"Account", {"name": ["like", "%Miscellaneous Expenses - CFC%"]}, "name"
 		)
+
+		# Provider-specific fields
+		if ps_code == "a":
+			eps.authorize_sending_endpoint = provider_mapping[ps_code]["endpoint"]
+			eps.authorize_sending_api_key = provider_mapping[ps_code]["api_key"]
+			eps.authorize_sending_transaction_key = provider_mapping[ps_code]["transaction_key"]
+		elif ps_code == "m":
+			eps.mercury_sending_endpoint = provider_mapping[ps_code]["endpoint"]
+			eps.mercury_sending_api_key = provider_mapping[ps_code]["api_key"]
+			eps.mercury_sending_account_id = provider_mapping[ps_code]["account_id"]
+		elif ps_code == "w":
+			eps.wise_sending_endpoint = provider_mapping[ps_code]["endpoint"]
+			eps.wise_sending_api_key = provider_mapping[ps_code]["api_key"]
+			eps.wise_sending_profile_id = provider_mapping[ps_code]["profile_id"]
+
 	eps.save()
 
 

--- a/electronic_payments/tests/test_common_funcs.py
+++ b/electronic_payments/tests/test_common_funcs.py
@@ -26,6 +26,7 @@ def create_electronic_payment_settings(
 	"""
 	Helper function to create Electronic Payment Settings for default company with dummy API keys
 	"""
+	provider = "Authorize.net"  # overrides parameter since field names are unique to provider
 	company = frappe.defaults.get_defaults().company
 	frappe.delete_doc_if_exists(
 		"Electronic Payment Settings",
@@ -36,9 +37,9 @@ def create_electronic_payment_settings(
 	eps.create_ppm = 1
 	eps.enable_accepting = 1
 	eps.provider = provider
-	eps.api_key = "123456789"
-	eps.transaction_key = "" if provider == "Stripe" else "987654321"
-	eps.endpoint = "www.example.com"
+	eps.authorize_accepting_api_key = "123456789"
+	eps.authorize_accepting_transaction_key = "987654321"
+	eps.authorize_accepting_endpoint = "www.example.com"
 	eps.use_clearing_account = clearing_acct
 	eps.deposit_account = "1201 - Primary Checking - CFC"
 	eps.accepting_fee_account = "5223 - Electronic Payments Provider Fees - CFC"
@@ -49,16 +50,15 @@ def create_electronic_payment_settings(
 	eps.enable_sending = int(provider == "Authorize.net")
 	if eps.enable_sending:
 		eps.sending_provider = provider
-		eps.sending_ref_id = eps.ref_id
-		eps.sending_endpoint = eps.endpoint
-		eps.sending_api_key = eps.api_key
-		eps.sending_transaction_key = eps.transaction_key
+		eps.authorize_sending_endpoint = eps.authorize_accepting_endpoint
+		eps.authorize_sending_api_key = eps.authorize_accepting_api_key
+		eps.authorize_sending_transaction_key = eps.authorize_accepting_transaction_key
 		eps.sending_use_clearing_account = clearing_acct
 		eps.withdrawal_account = eps.deposit_account
 		eps.sending_fee_account = eps.accepting_fee_account
 		eps.sending_clearing_account = "2130 - Electronic Payments Payable - CFC"
 		eps.sending_payment_discount_account = frappe.get_value(
-			"Account", {"name": ["like", "%Miscellaneous Expenses%"]}, "name"
+			"Account", {"name": ["like", "%Miscellaneous Expenses - CFC%"]}, "name"
 		)
 	eps.save()
 	return eps
@@ -936,7 +936,9 @@ def test_sending_payment_create_payment_entry_discount():
 		"taxes",
 		{
 			"charge_type": "Actual",
-			"account_head": frappe.get_value("Account", {"name": ["like", "%Freight%"]}),
+			"account_head": frappe.get_value(
+				"Account", {"name": ["like", "%Freight%"], "company": doc.company}
+			),
 			"description": "Freight",
 			"cost_center": "Main - CFC",
 			"tax_amount": 10,
@@ -946,7 +948,9 @@ def test_sending_payment_create_payment_entry_discount():
 		"taxes",
 		{
 			"charge_type": "Actual",
-			"account_head": frappe.get_value("Account", {"name": ["like", "%Marketing Expenses%"]}),
+			"account_head": frappe.get_value(
+				"Account", {"name": ["like", "%Marketing Expenses%"], "company": doc.company}
+			),
 			"description": "Marketing",
 			"cost_center": "Main - CFC",
 			"tax_amount": 5,
@@ -1195,7 +1199,9 @@ def test_sending_payment_create_journal_entry_discount():
 		"taxes",
 		{
 			"charge_type": "Actual",
-			"account_head": frappe.get_value("Account", {"name": ["like", "%Freight%"]}),
+			"account_head": frappe.get_value(
+				"Account", {"name": ["like", "%Freight%"], "company": doc.company}
+			),
 			"description": "Freight",
 			"cost_center": "Main - CFC",
 			"tax_amount": 10,
@@ -1205,7 +1211,9 @@ def test_sending_payment_create_journal_entry_discount():
 		"taxes",
 		{
 			"charge_type": "Actual",
-			"account_head": frappe.get_value("Account", {"name": ["like", "%Marketing Expenses%"]}),
+			"account_head": frappe.get_value(
+				"Account", {"name": ["like", "%Marketing Expenses%"], "company": doc.company}
+			),
 			"description": "Marketing",
 			"cost_center": "Main - CFC",
 			"tax_amount": 5,

--- a/electronic_payments/www/payment_methods/payment_method.py
+++ b/electronic_payments/www/payment_methods/payment_method.py
@@ -72,7 +72,7 @@ def edit_portal_payment_method(payment_method):
 	try:
 		doc = frappe._dict({party_data["party_type"].lower(): party_data["party"]})
 		client = settings.client(doc)
-		response = client.edit_customer_payment_profile(
+		response = client.edit_payment_profile(
 			settings.company, portal_payment_method.electronic_payment_profile, data
 		)
 		if response.get("error"):

--- a/electronic_payments/www/payments/index.py
+++ b/electronic_payments/www/payments/index.py
@@ -1,13 +1,16 @@
+# Copyright (c) 2025, AgriTheory and contributors
+# For license information, please see license.txt
+
 import frappe
 from frappe.utils.data import flt, fmt_money
 
-from electronic_payments.electronic_payments.doctype.electronic_payment_settings.electronic_payment_settings import (
-	process,
-)
 from electronic_payments.electronic_payments.doctype.electronic_payment_settings.common import (
 	exceeds_credit_limit,
-	get_payment_amount,
 	get_discount_amount,
+	get_payment_amount,
+)
+from electronic_payments.electronic_payments.doctype.electronic_payment_settings.electronic_payment_settings import (
+	process,
 )
 
 no_cache = 1
@@ -35,6 +38,11 @@ def get_context(context):
 	has_default = False
 	for pm in frappe.get_all("Portal Payment Method", {"parent": party}, order_by="`default` DESC"):
 		payment_method = frappe.get_doc("Portal Payment Method", pm.name)
+		pm_company = frappe.get_value(
+			"Electronic Payment Profile", payment_method.electronic_payment_profile, "company"
+		)
+		if pm_company != context.doc.company:
+			continue
 		fees = payment_method.calculate_payment_method_fees(
 			context.doc, amount=(payment_amount - discount_amount)
 		)


### PR DESCRIPTION
Closes #71 

- [x] Adds a new `BaseProvider` class, which lays out the expected methods for any new provider and has the logic for `process_transaction`
    - Raises `NotImplementedError` to indicate the method should be written at the provider-level
    - Docstrings note what the expected return values should be and behavior if the action isn't supported
    - Wise is the only provider that overrides the `process_transaction` logic, since the quote / batch group / direct debit work flow is very different than the others
    - diffs looks worse than the actual changes because I re-ordered the methods to come in same order as the base class
- [x] Refactors the Electronic Payment Settings doc so each provider has its own section and relevant fields
- [x] existing tests passing, UI tests working for all providers
- [ ] update documentation